### PR TITLE
fix(linux): field-report fixes — CWD anchor for logs.db, drop .deb channel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -404,9 +404,12 @@ jobs:
           echo '{"build":{"beforeBuildCommand":""}}' > .tauri-release-config.json
 
       # TAURI_TRAY=ayatana: the AppImage must link the ayatana appindicator
-      # (matching the deb dependency and what modern distros actually ship).
-      - name: Build and bundle app (AppImage + deb)
-        run: npx tauri build -b appimage,deb,updater --config .tauri-release-config.json
+      # (what modern distros actually ship). No deb: the Tauri v1 Linux
+      # updater can only replace AppImages, so a deb install would get
+      # update prompts it can never complete and then run stale — and stale
+      # versions break on game patches. AppImage is the only Linux channel.
+      - name: Build and bundle app (AppImage)
+        run: npx tauri build -b appimage,updater --config .tauri-release-config.json
         env:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
@@ -432,7 +435,6 @@ jobs:
             target/release/bundle/appimage/*.AppImage
             target/release/bundle/appimage/*.AppImage.tar.gz
             target/release/bundle/appimage/*.AppImage.tar.gz.sig
-            target/release/bundle/deb/*.deb
           if-no-files-found: error
 
   publish:
@@ -480,8 +482,8 @@ jobs:
           pattern: "*-bundle"
           merge-multiple: true
 
-      # The linux artifact preserves its bundle-dir structure (appimage/,
-      # deb/); flatten so make-latest-json.mjs and the asset glob below see
+      # The linux artifact preserves its bundle-dir structure (appimage/);
+      # flatten so make-latest-json.mjs and the asset glob below see
       # plain files.
       - name: Flatten downloaded artifacts
         run: |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Relink Logs runs natively on Linux and meters the Windows game running under
 Steam's Proton. Steam Deck gaming mode is **not** supported (an external
 overlay cannot draw over gamescope).
 
-1. Install the AppImage (auto-updates) or the .deb from the releases page.
+1. Download the AppImage from the releases page, make it executable
+   (`chmod +x`), and run it. It auto-updates itself on new releases.
 2. Launch Relink Logs, open **Settings → Linux setup**, and click
    **Install hook** if it isn't already green.
 3. One-time: in Steam → Granblue Fantasy: Relink → Properties → Launch
@@ -55,7 +56,7 @@ Notes:
   garbage in a log.
 - Ubuntu 24.04 ships only webkit2gtk-4.1, which the current build does not
   target — a known limitation; Ubuntu 22.04 (and distros still shipping
-  webkit2gtk-4.0) are what the AppImage and .deb are built against.
+  webkit2gtk-4.0) are what the AppImage is built against.
 
 ## Found a translation problem or a bug?
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1257,6 +1257,21 @@ fn main() {
         std::env::set_var("GDK_BACKEND", "x11");
     }
 
+    // logs.db and the logs/ folder are opened via CWD-relative paths. On
+    // Windows the installer's shortcut sets CWD to the (writable) install
+    // dir, but on Linux a desktop entry or AppImage launches with CWD = `/`
+    // or a read-only mount, so anchor the CWD to the XDG data dir instead.
+    #[cfg(target_os = "linux")]
+    {
+        let mut data_dir = tauri::api::path::data_dir()
+            .expect("Could not resolve the user data directory ($XDG_DATA_HOME)");
+        data_dir.push("gbfr-logs");
+        std::fs::create_dir_all(&data_dir)
+            .unwrap_or_else(|e| panic!("Failed to create {}: {e}", data_dir.display()));
+        std::env::set_current_dir(&data_dir)
+            .unwrap_or_else(|e| panic!("Failed to enter {}: {e}", data_dir.display()));
+    }
+
     info!("Starting application..");
 
     // Setup the database.


### PR DESCRIPTION
Fixes from the first Linux field report:

- **Instant crash on launch (SQLITE_CANTOPEN):** `logs.db` and the `logs/` folder are opened via CWD-relative paths, and an AppImage/desktop-entry launch starts with CWD at `/` or a read-only mount. Now chdirs to `~/.local/share/gbfr-logs` on Linux only — Windows keeps its install-dir CWD, which the injector and existing databases rely on.
- **Drop the .deb bundle:** the Tauri v1 Linux updater can only replace AppImages, so .deb installs get update prompts they can never complete and then run stale — and stale versions break on game patches. AppImage is now the only Linux channel; README updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)