### PR TITLE
fix(linux): pin bundled webkit2gtk to 2.36 to fix EGL_BAD_PARAMETER abort

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,10 +140,20 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      # webkit2gtk pinned to 2.36 to match release.yaml (see the rationale
+      # there) — checking against the same version the AppImage bundles means
+      # a 2.36 API incompatibility fails the PR, not the release run.
       - name: Install Tauri v1 Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y --allow-downgrades \
+            libwebkit2gtk-4.0-dev=2.36.0-2ubuntu1 \
+            libwebkit2gtk-4.0-37=2.36.0-2ubuntu1 \
+            libjavascriptcoregtk-4.0-dev=2.36.0-2ubuntu1 \
+            libjavascriptcoregtk-4.0-18=2.36.0-2ubuntu1 \
+            gir1.2-javascriptcoregtk-4.0=2.36.0-2ubuntu1 \
+            gir1.2-webkit2-4.0=2.36.0-2ubuntu1 \
+            build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
       # Same pinned-toolchain rationale as cargo_test: `rustup update nightly`
       # would churn rust-cache's environment hash daily.
       - name: Install pinned Rust toolchain

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -368,10 +368,26 @@ jobs:
           node-version: 20
           cache: npm
 
+      # webkit2gtk is pinned to the jammy release pocket (2.36): the AppImage
+      # bundles whatever webkit CI installs, and jammy-updates has moved to
+      # 2.50, where DMA-BUF is the only rendering path (the X11/WPE renderers
+      # and WEBKIT_DISABLE_DMABUF_RENDERER were removed in 2.44). On hosts
+      # where its EGL/GBM init fails — NVIDIA proprietary, newer Mesa — the
+      # web process aborts with "Could not create default EGL display:
+      # EGL_BAD_PARAMETER" and the app shows nothing. 2.36 predates that
+      # renderer and falls back gracefully everywhere (field-verified failure
+      # on two of three Linux testers; same pin as gitbutler#5301).
       - name: Install Tauri v1 Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y --allow-downgrades \
+            libwebkit2gtk-4.0-dev=2.36.0-2ubuntu1 \
+            libwebkit2gtk-4.0-37=2.36.0-2ubuntu1 \
+            libjavascriptcoregtk-4.0-dev=2.36.0-2ubuntu1 \
+            libjavascriptcoregtk-4.0-18=2.36.0-2ubuntu1 \
+            gir1.2-javascriptcoregtk-4.0=2.36.0-2ubuntu1 \
+            gir1.2-webkit2-4.0=2.36.0-2ubuntu1 \
+            build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
 
       - name: Install pinned Rust toolchain
         run: |

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1257,6 +1257,19 @@ fn main() {
         std::env::set_var("GDK_BACKEND", "x11");
     }
 
+    // The transparent overlay only stays transparent on WebKitGTK's software
+    // (Cairo) path: when accelerated compositing engages — it's on-demand, a
+    // CSS animation can trigger it mid-session — the GL surface loses its
+    // alpha channel and the whole webview composites onto an opaque backdrop,
+    // so the transparency slider appears dead (field report). Keep compositing
+    // off; must be set before any webview exists, and only bites with the
+    // webkit 2.36 the AppImage pins (2.44+ dropped these escape hatches).
+    // Respect an explicit user choice.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+    }
+
     info!("Starting application..");
 
     // Setup the database.


### PR DESCRIPTION
Two Linux rendering fixes that share one theme: keep WebKitGTK on boring, software-safe paths.

## 1. EGL_BAD_PARAMETER abort → pin bundled webkit2gtk to 2.36

2 of 3 Linux testers can't launch the AppImage — both die with:

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

(reporters: CachyOS + KDE Plasma + Proton Experimental; a mesa 26.1.5 host running 1.12.1-3, so the XDG-path/CSS fixes don't help them.)

The Tauri v1 AppImage bundles whatever `libwebkit2gtk-4.0` the ubuntu-22.04 runner installs. jammy-updates has security-bumped that to **2.50.4** (verified in the 1.12.1-3 build-linux log). WebKitGTK **2.44 removed the X11/WPE renderers** — DMA-BUF is the only rendering path and `WEBKIT_DISABLE_DMABUF_RENDERER` is a no-op — so on hosts where EGL/GBM init fails (NVIDIA proprietary, very new Mesa vs the bundle's 22.04-era libs) the web process aborts with no fallback.

Fix: pin the jammy **release-pocket 2.36.0-2ubuntu1** webkit2gtk package set in `release.yaml` — the pre-DMA-BUF renderer with graceful fallbacks that every Tauri v1 AppImage bundled until CI images picked up the webkit security updates. Same fix GitButler shipped for the identical report (gitbutler/gitbutler#5301 for gitbutler/gitbutler#5282). `ci.yaml`'s `cargo_check_linux` gets the same pin so PR CI compiles against the version the release actually bundles.

Not an X11-vs-Wayland issue: we already force `GDK_BACKEND=x11`, and the failing KDE user was on XWayland. A separate Wayland AppImage would fix nothing (and native Wayland loses always-on-top).

## 2. Overlay stuck at full opacity → force WEBKIT_DISABLE_COMPOSITING_MODE=1

Testers also report the overlay fully opaque with the transparency slider doing nothing. The slider's `rgba` background is fine — WebKitGTK's accelerated-compositing path composites the page onto an opaque backdrop, so `rgba(22,22,22,α)` blends against solid black and every slider value looks identical. Compositing is on-demand, so any content trigger (CSS animation/transform) flips a session opaque.

Fix: `main()` now sets `WEBKIT_DISABLE_COMPOSITING_MODE=1` on Linux (unless the user set it), before any webview exists — same respect-user-override pattern as the existing `GDK_BACKEND=x11` block. On 2.36's Cairo path this renders into a true ARGB surface, the classic known-good Tauri v1 transparent-overlay recipe. Process-wide software rendering is a non-issue for a DPS meter + SVG-chart logs page, and further reduces our dependence on host GPU stacks.

## Compat notes

- Our CSS uses nothing newer than gradients/CSS vars (grep-verified); Mantine's six `:has()` disabled-state selectors degrade cosmetically at worst.
- Vite 5's default JS target is within 2.36's JavaScriptCore.
- webkit 2.36 CVEs: accepted — the webview renders only our local frontend, never remote content.
- Transparency still requires a compositing window manager (any KDE/GNOME/Wayland session qualifies; a bare X11 session without one has no window transparency at all).

## Validation

- The `Rust - Linux check` job installs the pinned packages (log-verified pulling `2.36.0-2ubuntu1` from jammy/main) and compiles the workspace — including the new `cfg(linux)` block — against them.
- After merge, the next dev RC needs the field pass from **all three** Linux reporters: the two EGL-abort users (launch at all), plus overlay transparency + slider, and the currently-working Proton user for regressions, since their validation was against the 2.50 bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)