### PR TITLE
feat(logs): draw Repeat Quest chains as grouped blocks the pager respects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ version without a section here, and the section body becomes the GitHub
 release body — which the in-app update prompt shows as patch notes. Renders
 markdown in the app.
 
+## 1.12.8
+
+### Notes
+
+- Some Cheat Audit rules have been relaxed slightly
+  - The Perfect Overmasteries rule has been changed to only trigger on 3x max Stun Power from OM1. Perfect Overmastery rolls from OM3 are too commmon to be flagged. [suggested by](https://github.com/Foxschwarzengel)
+  - The Perfect Summons rule now only fires when the character has **four** perfect summons which is extremely unlikely. [issue raised by](https://github.com/KakiraMikoshiJD5)
+
+### Features
+
+- Repeat Quest runs are now grouped in the quest list
+  - The duration/IGT columns for the grouped rows display the best time for that group
+
+### Bug Fixes
+
+- Player level show now show correctly in the Equipment/Build tabs. [contributed by](https://github.com/imnotsureyi-sys)
+- The number of rolls for Overmastery Predictor / Transmarvel Wishlist is now persistent. [reported by](https://github.com/makisevon)
+- The Sup% column now properly excludes pets ( ex. Ferry's ghosts ) / summons because they cannot deal supplementary damage. [reported by](https://github.com/imnotsureyi-sys)
+- Repeated quests now properly show their own in-game time instead of copying the first run of the group. reported by TJL in discord
+- The Cheat Audit will now properly flag:
+  - Invalid wrightstone traits
+  - Immortal Shell+ sigils
+
 ## 1.12.7
 
 ### Features

--- a/src-tauri/examples/legality_stone_probe.rs
+++ b/src-tauri/examples/legality_stone_probe.rs
@@ -1,0 +1,149 @@
+//! Diagnostic: would a wrightstone TRAIT-MEMBERSHIP rule accuse honest players?
+//!
+//! `legality::wrightstone` judges only levels today, on the explicit reasoning
+//! that the transmarvel gacha configs "say nothing about stones from other
+//! sources". The user has asked for a membership rule, so the question this
+//! answers is the calibration one: how many traits on real, stored stones fall
+//! outside the pool the gacha configs can produce, and are they concentrated in
+//! a few builds (signal) or spread across the whole database (a table that does
+//! not cover every stone)?
+//!
+//! Run: cargo run -p gbfr-logs --example legality_stone_probe -- --db <logs.db>
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OpenFlags};
+
+use gbfr_logs::legality::is_empty;
+use gbfr_logs::transmarvel;
+
+/// Every trait the gacha configs can put on a stone: the four family primaries
+/// plus everything reachable through each config's `type_row`, plus any slot
+/// the config fixes outright.
+fn gacha_pool() -> HashSet<u32> {
+    let tables = transmarvel::stock_tables();
+    let mut pool = HashSet::new();
+
+    for config in tables.stone_configs.values() {
+        pool.insert(config.trait1);
+
+        if let Some(options) = tables.skill_type_rows.get(&config.type_row) {
+            for &(lot_hash, _weight) in options {
+                if let Some(traits) = tables.skill_lots.get(&lot_hash) {
+                    pool.extend(traits.iter().copied());
+                }
+            }
+        }
+
+        for slot in &config.slots {
+            if slot.skill != 0 {
+                pool.insert(slot.skill);
+            }
+        }
+    }
+
+    pool
+}
+
+fn main() -> Result<()> {
+    let mut db_path = PathBuf::from("src-tauri/logs.db");
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--db" => db_path = args.next().context("--db needs a path")?.into(),
+            other => anyhow::bail!("unknown arg: {other}"),
+        }
+    }
+
+    let pool = gacha_pool();
+    println!("gacha pool: {} traits", pool.len());
+
+    let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let mut stmt = conn.prepare("SELECT id, version, data FROM logs ORDER BY id")?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, u64>(0)?,
+            row.get::<_, u8>(1)?,
+            row.get::<_, Vec<u8>>(2)?,
+        ))
+    })?;
+
+    // Off-pool trait -> (sightings, the players carrying it).
+    let mut off_pool: BTreeMap<u32, (usize, BTreeSet<String>)> = BTreeMap::new();
+    let mut off_pool_players: BTreeSet<String> = BTreeSet::new();
+    let mut all_players: BTreeSet<String> = BTreeSet::new();
+    let mut readings = 0usize;
+    let mut in_pool = 0usize;
+    let mut logs = 0usize;
+    let mut skipped = 0usize;
+    let mut partial = 0usize;
+
+    for row in rows {
+        let (_log_id, version, blob) = row?;
+        logs += 1;
+        let parser = match gbfr_logs::parser::deserialize_version(&blob, version) {
+            Ok(parser) => parser,
+            Err(_) => {
+                skipped += 1;
+                continue;
+            }
+        };
+
+        for player in parser.encounter.player_data.iter().flatten() {
+            let name = player.display_name().to_string();
+            all_players.insert(name.clone());
+
+            let Some(state) = player.legality_inputs().weapon_state else {
+                continue;
+            };
+            // The level rule's own guard: fewer than three pairs is a partial
+            // remote read, never a shorter stone.
+            if state.wrightstone_traits.len() != 3 {
+                partial += 1;
+                continue;
+            }
+
+            for pair in &state.wrightstone_traits {
+                if is_empty(pair.id) {
+                    continue;
+                }
+                readings += 1;
+                if pool.contains(&pair.id) {
+                    in_pool += 1;
+                } else {
+                    let entry = off_pool.entry(pair.id).or_default();
+                    entry.0 += 1;
+                    entry.1.insert(name.clone());
+                    off_pool_players.insert(name.clone());
+                }
+            }
+        }
+    }
+
+    println!("logs: {logs} (skipped {skipped}), partial stone reads: {partial}");
+    println!(
+        "trait readings: {readings} — {in_pool} in pool, {} off",
+        readings - in_pool
+    );
+    println!(
+        "players: {} total, {} carrying an off-pool trait",
+        all_players.len(),
+        off_pool_players.len()
+    );
+    println!("\noff-pool traits, most-seen first:");
+
+    let mut ranked: Vec<_> = off_pool.into_iter().collect();
+    ranked.sort_by_key(|(_, (count, _))| std::cmp::Reverse(*count));
+    for (trait_id, (count, players)) in ranked {
+        let names: Vec<&str> = players.iter().map(String::as_str).take(6).collect();
+        println!(
+            "  {trait_id:08x}  {count:>5} sightings  {:>3} players  {}",
+            players.len(),
+            names.join(", ")
+        );
+    }
+
+    Ok(())
+}

--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -527,8 +527,10 @@
       "builds": "Builds",
       "ai-companion": "AI",
       "imported-tooltip": "This log was imported from another version of GBFR Logs and may be missing data that version never recorded.",
-      "repeat-chain-count": "×{{count}}",
-      "repeat-chain-tooltip": "Repeated quest — {{count}} runs chained with Repeat Quest. Click to expand or collapse."
+      "repeat-chain-toggle_one": "Show or hide the run in this Repeat Quest chain",
+      "repeat-chain-toggle_other": "Show or hide the {{count}} runs in this Repeat Quest chain",
+      "repeat-chain-select_one": "Select the run in this Repeat Quest chain",
+      "repeat-chain-select_other": "Select all {{count}} runs in this Repeat Quest chain"
     },
     "toolbox": {
       "title": "Toolbox",

--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -281,21 +281,20 @@
       "player-flagged": "This build was flagged",
       "limit": {
         "wrightstoneTraitLevel": "max {{allowed}}",
+        "wrightstoneTrait": "can't be engraved",
         "sigilTraitLevel": "max {{allowed}}",
         "sigilLockedPair": "wrong pair",
         "sigilQuestLockedTrait": "quest-only trait",
         "sigilSingleTraitOnly": "second trait",
         "overmasteryValue": "off-ladder value",
-        "overmasteryAllMaxed": "3 max Stun Power Up rolls — {{chance}}",
+        "overmasteryAllMaxed": "3 max Stun Power Up rolls",
         "summonTrait": "can't roll here",
         "summonBonusSource": "wrong bonus id — only {{allowed}}",
         "summonBonusSource-unnamed": "wrong bonus id",
         "summonBonusMagnitude": "max {{allowed}}",
-        "summonPerfectCount": "{{observed}} perfect summon rolls — {{chance}}",
+        "summonPerfectCount": "{{observed}} perfect summon rolls",
         "masterTraitCount": "max {{allowed}}"
       },
-      "chance-percent": "{{percent}}% chance",
-      "chance-impossible": "completely impossible",
       "violation": {
         "impossibleSigil": "Impossible Sigil",
         "impossibleWrightstone": "Impossible Wrightstone",
@@ -770,7 +769,6 @@
     },
     "Pl0200": {
       "0": "Ares (Link attack bug)",
-      "9998": "Ares",
       "100": "Attack 1",
       "101": "Attack 2",
       "102": "Attack 3",
@@ -802,6 +800,7 @@
       "303": "Aerial Finisher",
       "400": "Launch",
       "410": "Aerial Barrage",
+      "9998": "Ares",
       "skill-groups": {
         "normal-attack": "Normal Attack",
         "finisher": "Finisher",
@@ -1603,8 +1602,8 @@
       "400": "Launch",
       "410": "Aerial Barrage",
       "1000": "Deathmatch Finale",
-      "11000": "Mode Change",
       "1410": "Martial Spear Finisher",
+      "11000": "Mode Change",
       "skill-groups": {
         "normal-attack": "Normal Attack",
         "combo-finisher": "Combo Finisher",

--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -281,7 +281,7 @@
       "player-flagged": "This build was flagged",
       "limit": {
         "wrightstoneTraitLevel": "max {{allowed}}",
-        "wrightstoneTrait": "can't be engraved",
+        "wrightstoneTrait": "can't roll here",
         "sigilTraitLevel": "max {{allowed}}",
         "sigilLockedPair": "wrong pair",
         "sigilQuestLockedTrait": "quest-only trait",

--- a/src-tauri/src/db/logs.rs
+++ b/src-tauri/src/db/logs.rs
@@ -166,22 +166,51 @@ fn sort_value_expr(sort_by: &SortType) -> SimpleExpr {
     }
 }
 
-/// The filters every quest-list query shares.
+/// Which direction the list reads in.
+fn sort_order(sort_direction: &SortDirection) -> Order {
+    match sort_direction {
+        SortDirection::Ascending => Order::Asc,
+        SortDirection::Descending => Order::Desc,
+    }
+}
+
+/// What the user has narrowed the quest list to.
 ///
-/// One spelling of them: the page query, the chain-key query that decides which
-/// chains the page holds, and the count all have to select the same rows, and
-/// three hand-kept copies of a nine-branch condition chain would not stay equal.
-/// A count that disagreed with the list promises pages the list cannot fill.
-#[allow(clippy::too_many_arguments)]
-fn apply_log_filters(
-    query: &mut SelectStatement,
-    filter_by_enemy_id: Option<u32>,
-    filter_by_quest_id: Option<u32>,
-    cleared: Option<bool>,
-    filter_by_player_id: &Option<String>,
-    filter_by_player_character: &Option<String>,
-    flagged_only: bool,
-) {
+/// One value rather than six positional arguments: every query below has to
+/// select the same rows, and threaded by hand they were six parameters deep on
+/// four signatures — with two `Option<u32>` and an `Option<bool>` adjacent, so a
+/// transposed pair compiled silently. A filter added here reaches every reader
+/// at once, which is what keeps a count from disagreeing with the list it sizes.
+pub struct LogFilters<'a> {
+    pub enemy_id: Option<u32>,
+    pub quest_id: Option<u32>,
+    pub cleared: Option<bool>,
+    pub player_id: &'a Option<String>,
+    pub player_character: &'a Option<String>,
+    pub flagged_only: bool,
+}
+
+/// What the filtered list holds, counted two ways — see `get_counts`.
+pub struct LogCounts {
+    /// Runs: the "N saved" figure beside the pager.
+    pub logs: i32,
+    /// Chains: what the list pages through.
+    pub chains: i32,
+}
+
+/// The one spelling of the filters, applied to whichever query is being built:
+/// the page query, the chain-key query that decides which chains the page holds,
+/// and both counts.
+fn apply_log_filters(query: &mut SelectStatement, filters: &LogFilters) {
+    let &LogFilters {
+        enemy_id: filter_by_enemy_id,
+        quest_id: filter_by_quest_id,
+        cleared,
+        player_id: filter_by_player_id,
+        player_character: filter_by_player_character,
+        flagged_only,
+    } = filters;
+
     query
         // Exclude Conflux rooms: they are `logs` rows tagged with a run_id and
         // belong to the Conflux tab, not the normal quest list.
@@ -294,24 +323,15 @@ fn apply_log_filters(
 /// standalone runs. The figures the summary row shows are about the whole set;
 /// where the block SITS is about its best run, which is also the run the list
 /// marks inside it.
-#[allow(clippy::too_many_arguments)]
 fn page_chain_keys(
     conn: &Connection,
-    filter_by_enemy_id: Option<u32>,
-    filter_by_quest_id: Option<u32>,
+    filters: &LogFilters,
     per_page: u32,
     offset: u32,
     sort_by: &SortType,
     sort_direction: &SortDirection,
-    cleared: Option<bool>,
-    filter_by_player_id: &Option<String>,
-    filter_by_player_character: &Option<String>,
-    flagged_only: bool,
 ) -> Result<Vec<i64>> {
-    let order = match sort_direction {
-        SortDirection::Ascending => Order::Asc,
-        SortDirection::Descending => Order::Desc,
-    };
+    let order = sort_order(sort_direction);
 
     // Which end of the chain speaks for it follows the direction: the run the
     // sort would put first is the one at the MIN end ascending and at the MAX
@@ -331,15 +351,7 @@ fn page_chain_keys(
 
     let mut query = Query::select();
     query.from(Logs::Table).expr(chain_key_expr());
-    apply_log_filters(
-        &mut query,
-        filter_by_enemy_id,
-        filter_by_quest_id,
-        cleared,
-        filter_by_player_id,
-        filter_by_player_character,
-        flagged_only,
-    );
+    apply_log_filters(&mut query, filters);
 
     let (sql, values) = query
         .add_group_by([chain_key_expr()])
@@ -368,38 +380,18 @@ fn page_chain_keys(
 /// flagged in; false (the default) does not filter on legality at all.
 pub fn get_logs(
     conn: &Connection,
-    filter_by_enemy_id: Option<u32>,
-    filter_by_quest_id: Option<u32>,
+    filters: &LogFilters,
     per_page: u32,
     offset: u32,
     sort_by: &SortType,
     sort_direction: &SortDirection,
-    cleared: Option<bool>,
-    filter_by_player_id: &Option<String>,
-    filter_by_player_character: &Option<String>,
-    flagged_only: bool,
 ) -> anyhow::Result<Vec<LogEntry>> {
-    let order = match sort_direction {
-        SortDirection::Ascending => Order::Asc,
-        SortDirection::Descending => Order::Desc,
-    };
+    let order = sort_order(sort_direction);
 
     // Which chains this page holds. Selected first, then every run belonging to
     // them is fetched whole — paging the rows directly is what used to cut a
     // chain across the boundary.
-    let chain_keys = page_chain_keys(
-        conn,
-        filter_by_enemy_id,
-        filter_by_quest_id,
-        per_page,
-        offset,
-        sort_by,
-        sort_direction,
-        cleared,
-        filter_by_player_id,
-        filter_by_player_character,
-        flagged_only,
-    )?;
+    let chain_keys = page_chain_keys(conn, filters, per_page, offset, sort_by, sort_direction)?;
 
     if chain_keys.is_empty() {
         return Ok(vec![]);
@@ -427,22 +419,14 @@ pub fn get_logs(
         Logs::Imported,
         Logs::RepeatGroup,
     ]);
-    apply_log_filters(
-        &mut query,
-        filter_by_enemy_id,
-        filter_by_quest_id,
-        cleared,
-        filter_by_player_id,
-        filter_by_player_character,
-        flagged_only,
-    );
+    apply_log_filters(&mut query, filters);
 
     // The same reading of the column the chains were placed by, so a run cannot
     // lead its own chain on a time the block was not ranked by — and so the
     // rows the list draws as "-" sit at the bottom of the block rather than
     // claiming its record.
     let (sql, values) = query
-        .and_where(Expr::expr(chain_key_expr()).is_in(chain_keys.clone()))
+        .and_where(Expr::expr(chain_key_expr()).is_in(chain_keys.iter().copied()))
         .order_by_expr_with_nulls(
             sort_value_expr(sort_by),
             order,
@@ -505,158 +489,35 @@ pub fn get_logs(
     Ok(rows)
 }
 
-/// How many CHAINS the same filters match — the number of things the list
-/// pages through, since a Repeat Quest chain occupies one slot on a page
-/// however many runs it holds. Counting rows here would promise more pages than
-/// the list can fill.
+/// How many runs and how many chains the same filters match.
 ///
-/// Takes `flagged_only` for the same reason it takes every other filter: a
-/// count that ignored one would disagree with the list it sizes.
-pub fn get_chains_count(
-    conn: &Connection,
-    filter_by_enemy_id: Option<u32>,
-    filter_by_quest_id: Option<u32>,
-    cleared: Option<bool>,
-    filter_by_player_id: &Option<String>,
-    filter_by_player_character: &Option<String>,
-    flagged_only: bool,
-) -> Result<i32> {
+/// Both in one pass: they differ only in the aggregate, and the list needs each
+/// for a different job — the pager is sized in CHAINS, since a Repeat Quest
+/// chain occupies one slot however many runs it holds, while the "N saved"
+/// figure beside it is about the logs. Counting rows for the pager would promise
+/// more pages than the list can fill.
+///
+/// Answers to `flagged_only` for the same reason it answers to every other
+/// filter: a count that ignored one would disagree with the list it sizes.
+pub fn get_counts(conn: &Connection, filters: &LogFilters) -> Result<LogCounts> {
     let mut query = Query::select();
     query
+        .expr(Expr::col(Logs::Id).count())
         .expr(Expr::expr(chain_key_expr()).count_distinct())
         .from(Logs::Table);
-    apply_log_filters(
-        &mut query,
-        filter_by_enemy_id,
-        filter_by_quest_id,
-        cleared,
-        filter_by_player_id,
-        filter_by_player_character,
-        flagged_only,
-    );
+    apply_log_filters(&mut query, filters);
 
     let (sql, values) = query.build_rusqlite(SqliteQueryBuilder);
 
     let mut stmt = conn.prepare(&sql)?;
-    let row: i32 = stmt.query_row(&*values.as_params(), |r| r.get(0))?;
+    let counts = stmt.query_row(&*values.as_params(), |row| {
+        Ok(LogCounts {
+            logs: row.get(0)?,
+            chains: row.get(1)?,
+        })
+    })?;
 
-    Ok(row)
-}
-
-/// How many logs the same filters match, for the callers that count RUNS rather
-/// than chains — the "N saved" figure beside the pager.
-pub fn get_logs_count(
-    conn: &Connection,
-    filter_by_enemy_id: Option<u32>,
-    filter_by_quest_id: Option<u32>,
-    cleared: Option<bool>,
-    filter_by_player_id: &Option<String>,
-    filter_by_player_character: &Option<String>,
-    flagged_only: bool,
-) -> Result<i32> {
-    let (sql, values) = Query::select()
-        .expr(Expr::col(Logs::Id).count())
-        .from(Logs::Table)
-        // Exclude Conflux rooms (see get_logs) so the count matches the filtered list.
-        .and_where(Expr::col(Logs::RunId).is_null())
-        .conditions(
-            filter_by_enemy_id.is_some(),
-            |q| {
-                q.and_where(Expr::col(Logs::PrimaryTarget).eq(filter_by_enemy_id.unwrap()));
-            },
-            |_| {},
-        )
-        .conditions(
-            filter_by_quest_id.is_some(),
-            |q| {
-                q.and_where(Expr::col(Logs::QuestId).eq(filter_by_quest_id.unwrap()));
-            },
-            |_| {},
-        )
-        .conditions(
-            cleared.is_some(),
-            |q| {
-                q.and_where(Expr::col(Logs::QuestCompleted).eq(cleared.unwrap()));
-            },
-            |_| {},
-        )
-        .conditions(
-            filter_by_player_id.is_some() && filter_by_player_character.is_some(),
-            |q| {
-                let player_id = filter_by_player_id.as_ref().unwrap();
-                let player_character = filter_by_player_character.as_ref().unwrap();
-
-                q.cond_where(
-                    Condition::any()
-                        .add(
-                            Expr::col(Logs::P1Name)
-                                .eq(player_id.clone())
-                                .and(Expr::col(Logs::P1Type).eq(player_character.clone())),
-                        )
-                        .add(
-                            Expr::col(Logs::P2Name)
-                                .eq(player_id.clone())
-                                .and(Expr::col(Logs::P2Type).eq(player_character.clone())),
-                        )
-                        .add(
-                            Expr::col(Logs::P3Name)
-                                .eq(player_id.clone())
-                                .and(Expr::col(Logs::P3Type).eq(player_character.clone())),
-                        )
-                        .add(
-                            Expr::col(Logs::P4Name)
-                                .eq(player_id)
-                                .and(Expr::col(Logs::P4Type).eq(player_character)),
-                        ),
-                );
-            },
-            |_| {},
-        )
-        .conditions(
-            filter_by_player_id.is_some() && filter_by_player_character.is_none(),
-            |q| {
-                let player_id = filter_by_player_id.as_ref().unwrap();
-
-                q.cond_where(
-                    Condition::any()
-                        .add(Expr::col(Logs::P1Name).eq(player_id.clone()))
-                        .add(Expr::col(Logs::P2Name).eq(player_id.clone()))
-                        .add(Expr::col(Logs::P3Name).eq(player_id.clone()))
-                        .add(Expr::col(Logs::P4Name).eq(player_id)),
-                );
-            },
-            |_| {},
-        )
-        .conditions(
-            filter_by_player_id.is_none() && filter_by_player_character.is_some(),
-            |q| {
-                let player_character = filter_by_player_character.as_ref().unwrap();
-
-                q.cond_where(
-                    Condition::any()
-                        .add(Expr::col(Logs::P1Type).eq(player_character.clone()))
-                        .add(Expr::col(Logs::P2Type).eq(player_character.clone()))
-                        .add(Expr::col(Logs::P3Type).eq(player_character.clone()))
-                        .add(Expr::col(Logs::P4Type).eq(player_character)),
-                );
-            },
-            |_| {},
-        )
-        .conditions(
-            flagged_only,
-            |q| {
-                q.and_where(flagged_condition());
-            },
-            |_| {},
-        )
-        .build_rusqlite(SqliteQueryBuilder);
-
-    let mut stmt = conn.prepare(&sql).unwrap();
-    let params = values.as_params();
-
-    let row: i32 = stmt.query_row(&*params, |r| r.get(0))?;
-
-    Ok(row)
+    Ok(counts)
 }
 
 #[cfg(test)]
@@ -698,25 +559,39 @@ mod tests {
         logs.iter().map(|log| log.id).collect()
     }
 
+    /// A `LogFilters` borrows its two string filters, so the tests need
+    /// somewhere for an absent one to live.
+    static NO_FILTER: Option<String> = None;
+
+    /// Everything unfiltered but `flagged_only` — what nearly every case below
+    /// wants.
+    fn filters(flagged_only: bool) -> LogFilters<'static> {
+        LogFilters {
+            enemy_id: None,
+            quest_id: None,
+            cleared: None,
+            player_id: &NO_FILTER,
+            player_character: &NO_FILTER,
+            flagged_only,
+        }
+    }
+
     fn fetch(conn: &Connection, flagged_only: bool) -> Vec<LogEntry> {
         get_logs(
             conn,
-            None,
-            None,
+            &filters(flagged_only),
             10,
             0,
             &SortType::Time,
             &SortDirection::Ascending,
-            None,
-            &None,
-            &None,
-            flagged_only,
         )
         .expect("query")
     }
 
     fn count(conn: &Connection, flagged_only: bool) -> i32 {
-        get_logs_count(conn, None, None, None, &None, &None, flagged_only).expect("count")
+        get_counts(conn, &filters(flagged_only))
+            .expect("count")
+            .logs
     }
 
     /// Every listed log has somebody flagged in it — and one flagged player is
@@ -778,22 +653,17 @@ mod tests {
     fn page(conn: &Connection, per_page: u32, offset: u32) -> Vec<LogEntry> {
         get_logs(
             conn,
-            None,
-            None,
+            &filters(false),
             per_page,
             offset,
             &SortType::Time,
             &SortDirection::Ascending,
-            None,
-            &None,
-            &None,
-            false,
         )
         .expect("query")
     }
 
     fn chains(conn: &Connection) -> i32 {
-        get_chains_count(conn, None, None, None, &None, &None, false).expect("count")
+        get_counts(conn, &filters(false)).expect("count").chains
     }
 
     /// A page holds whole chains. Two slots against a 3-run chain and a lone
@@ -872,10 +742,7 @@ mod tests {
     }
 
     fn sorted(conn: &Connection, sort_by: &SortType, direction: &SortDirection) -> Vec<u64> {
-        ids(&get_logs(
-            conn, None, None, 10, 0, sort_by, direction, None, &None, &None, false,
-        )
-        .expect("query"))
+        ids(&get_logs(conn, &filters(false), 10, 0, sort_by, direction).expect("query"))
     }
 
     /// Sorting by in-game time ranks a chain by its FASTEST run, so asking for

--- a/src-tauri/src/db/logs.rs
+++ b/src-tauri/src/db/logs.rs
@@ -1,6 +1,10 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use rusqlite::Connection;
-use sea_query::{Condition, Expr, Iden, Order, Query, SimpleExpr, SqliteQueryBuilder};
+use sea_query::{
+    Condition, Expr, Func, Iden, Order, Query, SelectStatement, SimpleExpr, SqliteQueryBuilder,
+};
 use sea_query_rusqlite::RusqliteBinder;
 use serde::Serialize;
 
@@ -115,59 +119,72 @@ impl LogEntry {
     pub fn id(&self) -> i64 {
         self.id as i64
     }
+
+    /// The chain this log belongs to — the Rust twin of `chain_key_expr`.
+    fn chain_key(&self) -> i64 {
+        self.repeat_group.unwrap_or(self.id as i64)
+    }
 }
 
-/// One page of the quest list. `flagged_only` keeps just the logs somebody was
-/// flagged in; false (the default) does not filter on legality at all.
-pub fn get_logs(
-    conn: &Connection,
+/// The chain a log belongs to: its `repeat_group` if it is a later run of a
+/// Repeat Quest chain, otherwise its own id.
+///
+/// This is the unit the quest list pages by. Written the same way the frontend
+/// derives it (`chainKey` in `repeatChains.ts`) so a page boundary and a
+/// rendered group can never disagree about what a chain is.
+fn chain_key_expr() -> SimpleExpr {
+    Func::coalesce([
+        Expr::col(Logs::RepeatGroup).into(),
+        Expr::col(Logs::Id).into(),
+    ])
+    .into()
+}
+
+/// The shortest in-game clear time the game can actually report, in seconds.
+/// The Rust twin of `MIN_QUEST_ELAPSED_SECS` in `utils.ts` — logs recorded
+/// before the quest timer was read from the right offset stored a constant 1s,
+/// and the list renders anything below this as "-".
+const MIN_QUEST_ELAPSED_SECS: u32 = 2;
+
+/// The column a sort reads, with the values that are not really values folded
+/// to NULL so they sort as the absences they are.
+///
+/// Only in-game time has any: taken at face value the stored 1s placeholder is
+/// the fastest clear in the database, so "fastest first" would open on a page
+/// of rows the list draws as "-".
+fn sort_value_expr(sort_by: &SortType) -> SimpleExpr {
+    match sort_by {
+        SortType::Time => Expr::col(Logs::Time).into(),
+        SortType::Duration => Expr::col(Logs::Duration).into(),
+        // No ELSE, so a placeholder — and a log that never recorded a time —
+        // both come out NULL, and one NULL ordering covers the pair.
+        SortType::QuestElapsedTime => Expr::case(
+            Expr::col(Logs::QuestElapsedTime).gte(MIN_QUEST_ELAPSED_SECS),
+            Expr::col(Logs::QuestElapsedTime),
+        )
+        .into(),
+    }
+}
+
+/// The filters every quest-list query shares.
+///
+/// One spelling of them: the page query, the chain-key query that decides which
+/// chains the page holds, and the count all have to select the same rows, and
+/// three hand-kept copies of a nine-branch condition chain would not stay equal.
+/// A count that disagreed with the list promises pages the list cannot fill.
+#[allow(clippy::too_many_arguments)]
+fn apply_log_filters(
+    query: &mut SelectStatement,
     filter_by_enemy_id: Option<u32>,
     filter_by_quest_id: Option<u32>,
-    per_page: u32,
-    offset: u32,
-    sort_by: &SortType,
-    sort_direction: &SortDirection,
     cleared: Option<bool>,
     filter_by_player_id: &Option<String>,
     filter_by_player_character: &Option<String>,
     flagged_only: bool,
-) -> anyhow::Result<Vec<LogEntry>> {
-    let sort_column = match sort_by {
-        SortType::Time => Logs::Time,
-        SortType::Duration => Logs::Duration,
-        SortType::QuestElapsedTime => Logs::QuestElapsedTime,
-    };
-
-    let order = match sort_direction {
-        SortDirection::Ascending => Order::Asc,
-        SortDirection::Descending => Order::Desc,
-    };
-
-    let (sql, values) = Query::select()
-        .from(Logs::Table)
-        .columns([
-            Logs::Id,
-            Logs::Name,
-            Logs::Time,
-            Logs::Duration,
-            Logs::Version,
-            Logs::PrimaryTarget,
-            Logs::P1Name,
-            Logs::P1Type,
-            Logs::P2Name,
-            Logs::P2Type,
-            Logs::P3Name,
-            Logs::P3Type,
-            Logs::P4Name,
-            Logs::P4Type,
-            Logs::QuestId,
-            Logs::QuestElapsedTime,
-            Logs::QuestCompleted,
-            Logs::Imported,
-            Logs::RepeatGroup,
-        ])
-        // Exclude Conflux rooms: they are `logs` rows tagged with a run_id and belong to the
-        // Conflux tab, not the normal quest list.
+) {
+    query
+        // Exclude Conflux rooms: they are `logs` rows tagged with a run_id and
+        // belong to the Conflux tab, not the normal quest list.
         .and_where(Expr::col(Logs::RunId).is_null())
         .conditions(
             filter_by_enemy_id.is_some(),
@@ -215,8 +232,8 @@ pub fn get_logs(
                         )
                         .add(
                             Expr::col(Logs::P4Name)
-                                .eq(player_id)
-                                .and(Expr::col(Logs::P4Type).eq(player_character)),
+                                .eq(player_id.clone())
+                                .and(Expr::col(Logs::P4Type).eq(player_character.clone())),
                         ),
                 );
             },
@@ -232,7 +249,7 @@ pub fn get_logs(
                         .add(Expr::col(Logs::P1Name).eq(player_id.clone()))
                         .add(Expr::col(Logs::P2Name).eq(player_id.clone()))
                         .add(Expr::col(Logs::P3Name).eq(player_id.clone()))
-                        .add(Expr::col(Logs::P4Name).eq(player_id)),
+                        .add(Expr::col(Logs::P4Name).eq(player_id.clone())),
                 );
             },
             |_| {},
@@ -247,7 +264,7 @@ pub fn get_logs(
                         .add(Expr::col(Logs::P1Type).eq(player_character.clone()))
                         .add(Expr::col(Logs::P2Type).eq(player_character.clone()))
                         .add(Expr::col(Logs::P3Type).eq(player_character.clone()))
-                        .add(Expr::col(Logs::P4Type).eq(player_character)),
+                        .add(Expr::col(Logs::P4Type).eq(player_character.clone())),
                 );
             },
             |_| {},
@@ -258,10 +275,179 @@ pub fn get_logs(
                 q.and_where(flagged_condition());
             },
             |_| {},
-        )
-        .order_by_with_nulls(sort_column, order, sea_query::NullOrdering::Last)
+        );
+}
+
+/// The chain keys one page of the list holds, in display order.
+///
+/// A page is a fixed number of CHAINS, not of rows, so a Repeat Quest chain is
+/// never cut in half by a page boundary. It used to be: a chain straddling the
+/// break rendered as two blocks, each summarising only the runs that landed on
+/// its own page — two different averages for one chain, a "fastest run" that
+/// was merely the fastest of that half, and a different colour on each side of
+/// the break, which is precisely the signal that says the rows are one group.
+///
+/// A chain is placed by the run that would come FIRST on its own under the
+/// chosen sort — its fastest run ascending, its slowest descending. Asked for
+/// the quickest clears, the user means to find the chain that holds one, and a
+/// chain ranked by its own average or by its date would hide it behind slower
+/// standalone runs. The figures the summary row shows are about the whole set;
+/// where the block SITS is about its best run, which is also the run the list
+/// marks inside it.
+#[allow(clippy::too_many_arguments)]
+fn page_chain_keys(
+    conn: &Connection,
+    filter_by_enemy_id: Option<u32>,
+    filter_by_quest_id: Option<u32>,
+    per_page: u32,
+    offset: u32,
+    sort_by: &SortType,
+    sort_direction: &SortDirection,
+    cleared: Option<bool>,
+    filter_by_player_id: &Option<String>,
+    filter_by_player_character: &Option<String>,
+    flagged_only: bool,
+) -> Result<Vec<i64>> {
+    let order = match sort_direction {
+        SortDirection::Ascending => Order::Asc,
+        SortDirection::Descending => Order::Desc,
+    };
+
+    // Which end of the chain speaks for it follows the direction: the run the
+    // sort would put first is the one at the MIN end ascending and at the MAX
+    // end descending. Taking the minimum either way would rank a chain by its
+    // best run in a list asking which took longest.
+    //
+    // Time is the exception, and always the latest run. It is the one column
+    // whose summary cell shows a single run's value rather than a figure about
+    // the set — the chain's most recent date — so placing the band anywhere
+    // else would put a visible date out of order against the rows around it.
+    let placement: SimpleExpr = match (sort_by, sort_direction) {
+        (SortType::Time, _) | (_, SortDirection::Descending) => {
+            Func::max(sort_value_expr(sort_by)).into()
+        }
+        (_, SortDirection::Ascending) => Func::min(sort_value_expr(sort_by)).into(),
+    };
+
+    let mut query = Query::select();
+    query.from(Logs::Table).expr(chain_key_expr());
+    apply_log_filters(
+        &mut query,
+        filter_by_enemy_id,
+        filter_by_quest_id,
+        cleared,
+        filter_by_player_id,
+        filter_by_player_character,
+        flagged_only,
+    );
+
+    let (sql, values) = query
+        .add_group_by([chain_key_expr()])
+        // Nothing to rank by sorts last, not first: a chain of rows the list
+        // draws as "-" answers neither "fastest" nor "slowest".
+        .order_by_expr_with_nulls(placement, order.clone(), sea_query::NullOrdering::Last)
+        // Chains the sort column cannot separate — every untimed chain, and any
+        // genuine tie — fall back to the list's resting order, so they hold
+        // still between pages instead of arriving in whatever order the
+        // grouping happened to produce.
+        .order_by_expr(Expr::col(Logs::Time).max(), order)
         .limit(per_page.into())
         .offset(offset.into())
+        .build_rusqlite(SqliteQueryBuilder);
+
+    let mut stmt = conn.prepare(&sql)?;
+    let keys = stmt
+        .query(&*values.as_params())?
+        .mapped(|row| row.get::<_, i64>(0))
+        .collect::<rusqlite::Result<Vec<i64>>>()?;
+
+    Ok(keys)
+}
+
+/// One page of the quest list. `flagged_only` keeps just the logs somebody was
+/// flagged in; false (the default) does not filter on legality at all.
+pub fn get_logs(
+    conn: &Connection,
+    filter_by_enemy_id: Option<u32>,
+    filter_by_quest_id: Option<u32>,
+    per_page: u32,
+    offset: u32,
+    sort_by: &SortType,
+    sort_direction: &SortDirection,
+    cleared: Option<bool>,
+    filter_by_player_id: &Option<String>,
+    filter_by_player_character: &Option<String>,
+    flagged_only: bool,
+) -> anyhow::Result<Vec<LogEntry>> {
+    let order = match sort_direction {
+        SortDirection::Ascending => Order::Asc,
+        SortDirection::Descending => Order::Desc,
+    };
+
+    // Which chains this page holds. Selected first, then every run belonging to
+    // them is fetched whole — paging the rows directly is what used to cut a
+    // chain across the boundary.
+    let chain_keys = page_chain_keys(
+        conn,
+        filter_by_enemy_id,
+        filter_by_quest_id,
+        per_page,
+        offset,
+        sort_by,
+        sort_direction,
+        cleared,
+        filter_by_player_id,
+        filter_by_player_character,
+        flagged_only,
+    )?;
+
+    if chain_keys.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut query = Query::select();
+    query.from(Logs::Table).columns([
+        Logs::Id,
+        Logs::Name,
+        Logs::Time,
+        Logs::Duration,
+        Logs::Version,
+        Logs::PrimaryTarget,
+        Logs::P1Name,
+        Logs::P1Type,
+        Logs::P2Name,
+        Logs::P2Type,
+        Logs::P3Name,
+        Logs::P3Type,
+        Logs::P4Name,
+        Logs::P4Type,
+        Logs::QuestId,
+        Logs::QuestElapsedTime,
+        Logs::QuestCompleted,
+        Logs::Imported,
+        Logs::RepeatGroup,
+    ]);
+    apply_log_filters(
+        &mut query,
+        filter_by_enemy_id,
+        filter_by_quest_id,
+        cleared,
+        filter_by_player_id,
+        filter_by_player_character,
+        flagged_only,
+    );
+
+    // The same reading of the column the chains were placed by, so a run cannot
+    // lead its own chain on a time the block was not ranked by — and so the
+    // rows the list draws as "-" sit at the bottom of the block rather than
+    // claiming its record.
+    let (sql, values) = query
+        .and_where(Expr::expr(chain_key_expr()).is_in(chain_keys.clone()))
+        .order_by_expr_with_nulls(
+            sort_value_expr(sort_by),
+            order,
+            sea_query::NullOrdering::Last,
+        )
         .build_rusqlite(SqliteQueryBuilder);
 
     let mut stmt = conn.prepare(&sql).unwrap();
@@ -294,12 +480,71 @@ pub fn get_logs(
         })
         .collect::<rusqlite::Result<Vec<LogEntry>>>();
 
-    Ok(rows.unwrap_or(vec![]))
+    let mut rows = rows.unwrap_or_default();
+
+    // Put the chains back in the order the page query chose — by their most
+    // recent run — and keep each chain's runs together. The row query can only
+    // sort by the sort column, which interleaves chains whose runs overlap in
+    // time, and the list groups CONSECUTIVE runs only: an unrelated row landing
+    // mid-chain would split it into two blocks again.
+    //
+    // A stable sort, so within one chain the runs keep the order the sort
+    // column gave them.
+    let chain_order: HashMap<i64, usize> = chain_keys
+        .iter()
+        .enumerate()
+        .map(|(position, key)| (*key, position))
+        .collect();
+    rows.sort_by_key(|log| {
+        chain_order
+            .get(&log.chain_key())
+            .copied()
+            .unwrap_or(usize::MAX)
+    });
+
+    Ok(rows)
 }
 
-/// How many logs the same filters match. Takes `flagged_only` for the same
-/// reason it takes every other filter: a count that ignored one would promise
-/// pages the list cannot fill.
+/// How many CHAINS the same filters match — the number of things the list
+/// pages through, since a Repeat Quest chain occupies one slot on a page
+/// however many runs it holds. Counting rows here would promise more pages than
+/// the list can fill.
+///
+/// Takes `flagged_only` for the same reason it takes every other filter: a
+/// count that ignored one would disagree with the list it sizes.
+pub fn get_chains_count(
+    conn: &Connection,
+    filter_by_enemy_id: Option<u32>,
+    filter_by_quest_id: Option<u32>,
+    cleared: Option<bool>,
+    filter_by_player_id: &Option<String>,
+    filter_by_player_character: &Option<String>,
+    flagged_only: bool,
+) -> Result<i32> {
+    let mut query = Query::select();
+    query
+        .expr(Expr::expr(chain_key_expr()).count_distinct())
+        .from(Logs::Table);
+    apply_log_filters(
+        &mut query,
+        filter_by_enemy_id,
+        filter_by_quest_id,
+        cleared,
+        filter_by_player_id,
+        filter_by_player_character,
+        flagged_only,
+    );
+
+    let (sql, values) = query.build_rusqlite(SqliteQueryBuilder);
+
+    let mut stmt = conn.prepare(&sql)?;
+    let row: i32 = stmt.query_row(&*values.as_params(), |r| r.get(0))?;
+
+    Ok(row)
+}
+
+/// How many logs the same filters match, for the callers that count RUNS rather
+/// than chains — the "N saved" figure beside the pager.
 pub fn get_logs_count(
     conn: &Connection,
     filter_by_enemy_id: Option<u32>,
@@ -517,5 +762,238 @@ mod tests {
 
         assert_eq!(count(&conn, true), 2);
         assert_eq!(count(&conn, false), 4);
+    }
+
+    /// Stamps `ids` as later runs of the chain led by `parent`.
+    fn chain(conn: &Connection, parent: i64, ids: &[i64]) {
+        for id in ids {
+            conn.execute(
+                "UPDATE logs SET repeat_group = ? WHERE id = ?",
+                params![parent, id],
+            )
+            .expect("stamp chain");
+        }
+    }
+
+    fn page(conn: &Connection, per_page: u32, offset: u32) -> Vec<LogEntry> {
+        get_logs(
+            conn,
+            None,
+            None,
+            per_page,
+            offset,
+            &SortType::Time,
+            &SortDirection::Ascending,
+            None,
+            &None,
+            &None,
+            false,
+        )
+        .expect("query")
+    }
+
+    fn chains(conn: &Connection) -> i32 {
+        get_chains_count(conn, None, None, None, &None, &None, false).expect("count")
+    }
+
+    /// A page holds whole chains. Two slots against a 3-run chain and a lone
+    /// log used to mean the chain was cut after its second run, and the summary
+    /// row then averaged half a chain and marked the wrong run as fastest.
+    #[test]
+    fn a_page_never_cuts_a_chain_in_half() {
+        let conn = db_with(&[(1, false), (2, false), (3, false), (4, false)]);
+        chain(&conn, 1, &[2, 3]);
+
+        // Two slots: the chain (runs 1-3) and log 4. The chain arrives whole,
+        // so the page carries four rows rather than the two a row-pager would.
+        assert_eq!(ids(&page(&conn, 2, 0)), vec![1, 2, 3, 4]);
+    }
+
+    /// One slot per chain, so the second page starts at the next chain rather
+    /// than partway through the first.
+    #[test]
+    fn paging_steps_by_chain_not_by_row() {
+        let conn = db_with(&[(1, false), (2, false), (3, false), (4, false)]);
+        chain(&conn, 1, &[2, 3]);
+
+        assert_eq!(ids(&page(&conn, 1, 0)), vec![1, 2, 3]);
+        assert_eq!(ids(&page(&conn, 1, 1)), vec![4]);
+    }
+
+    /// The pager is sized in chains. Counting rows here would offer a second
+    /// page that the chain-based offset leaves empty.
+    #[test]
+    fn the_chain_count_counts_chains_not_runs() {
+        let conn = db_with(&[(1, false), (2, false), (3, false), (4, false)]);
+        chain(&conn, 1, &[2, 3]);
+
+        assert_eq!(chains(&conn), 2);
+        assert_eq!(count(&conn, false), 4);
+    }
+
+    /// A chain's runs stay together even when another log falls between them in
+    /// the sort order — the list groups CONSECUTIVE runs only, so an interloper
+    /// would split one chain into two blocks.
+    ///
+    /// The chain sits where its MOST RECENT run puts it, which is the date its
+    /// summary row shows: ascending by time, the lone log 2 precedes a chain
+    /// whose latest run is 3, and both of the chain's runs follow together.
+    ///
+    /// Ascending, that is the LAST of the chain's runs rather than the first —
+    /// time does not follow the direction the way duration and in-game time do
+    /// (see `page_chain_keys`). The band displays this date, so ranking it by
+    /// the chain's earliest run would print 3 above a row printing 2.
+    #[test]
+    fn a_chain_stays_contiguous_when_another_log_sorts_between_its_runs() {
+        let conn = db_with(&[(1, false), (2, false), (3, false)]);
+        // Log 2 sits between runs 1 and 3 by time, but belongs to no chain.
+        chain(&conn, 1, &[3]);
+
+        assert_eq!(ids(&page(&conn, 10, 0)), vec![2, 1, 3]);
+    }
+
+    /// Gives logs an in-game clear time, in the seconds the column stores.
+    fn igt(conn: &Connection, times: &[(i64, i64)]) {
+        for (id, seconds) in times {
+            conn.execute(
+                "UPDATE logs SET quest_elapsed_time = ? WHERE id = ?",
+                params![seconds, id],
+            )
+            .expect("set quest elapsed time");
+        }
+    }
+
+    /// Gives logs a wall-clock duration, in the milliseconds the column stores.
+    fn durations(conn: &Connection, values: &[(i64, i64)]) {
+        for (id, ms) in values {
+            conn.execute("UPDATE logs SET duration = ? WHERE id = ?", params![ms, id])
+                .expect("set duration");
+        }
+    }
+
+    fn sorted(conn: &Connection, sort_by: &SortType, direction: &SortDirection) -> Vec<u64> {
+        ids(&get_logs(
+            conn, None, None, 10, 0, sort_by, direction, None, &None, &None, false,
+        )
+        .expect("query"))
+    }
+
+    /// Sorting by in-game time ranks a chain by its FASTEST run, so asking for
+    /// the quickest clears surfaces the chain that holds one. Ranking it by its
+    /// most recent run instead — which is all the chain pager knew — left the
+    /// list in time order under every sort column.
+    #[test]
+    fn an_in_game_time_sort_places_a_chain_by_its_fastest_run() {
+        let conn = db_with(&[(1, false), (2, false), (3, false), (4, false)]);
+        chain(&conn, 1, &[3]);
+        igt(&conn, &[(1, 300), (2, 200), (3, 100), (4, 400)]);
+
+        // The chain holds the fastest clear (100s), so it leads — its own runs
+        // fastest-first — then the lone logs by their own times.
+        assert_eq!(
+            sorted(
+                &conn,
+                &SortType::QuestElapsedTime,
+                &SortDirection::Ascending
+            ),
+            vec![3, 1, 2, 4]
+        );
+    }
+
+    /// An unchained log is a chain of one, so the sort column has to move it
+    /// too. It did not: every log was its own chain, and chains were ordered by
+    /// time whatever column the user clicked.
+    #[test]
+    fn an_in_game_time_sort_orders_unchained_logs_by_their_own_time() {
+        let conn = db_with(&[(1, false), (2, false), (3, false)]);
+        igt(&conn, &[(1, 300), (2, 100), (3, 200)]);
+
+        assert_eq!(
+            sorted(
+                &conn,
+                &SortType::QuestElapsedTime,
+                &SortDirection::Ascending
+            ),
+            vec![2, 3, 1]
+        );
+    }
+
+    /// Descending, the question is "which took longest", so a chain is ranked
+    /// by its SLOWEST run — the same rule as ascending, read from the other
+    /// end. Ranking by the fastest either way would bury a chain holding the
+    /// longest clear in the list.
+    #[test]
+    fn a_descending_sort_places_a_chain_by_its_slowest_run() {
+        let conn = db_with(&[(1, false), (2, false), (3, false), (4, false)]);
+        chain(&conn, 1, &[3]);
+        // The newest log (4) holds neither the longest nor the shortest clear,
+        // so time order and in-game order disagree everywhere.
+        igt(&conn, &[(1, 300), (2, 400), (3, 100), (4, 200)]);
+
+        assert_eq!(
+            sorted(
+                &conn,
+                &SortType::QuestElapsedTime,
+                &SortDirection::Descending
+            ),
+            vec![2, 1, 3, 4]
+        );
+    }
+
+    /// The placeholder in-game time is not a clear time, so it cannot win the
+    /// sort. Logs recorded before the quest timer was read correctly store a
+    /// constant 1s; taken at face value it is the fastest clear in the database
+    /// and would pin every chain holding one to the top of an ascending sort.
+    #[test]
+    fn a_placeholder_in_game_time_does_not_place_a_chain() {
+        let conn = db_with(&[(1, false), (2, false), (3, false)]);
+        chain(&conn, 1, &[3]);
+        // Run 3 stored the placeholder, so the chain's real best is run 1's
+        // 300s — behind the lone log's 200s.
+        igt(&conn, &[(1, 300), (2, 200), (3, 1)]);
+
+        assert_eq!(
+            sorted(
+                &conn,
+                &SortType::QuestElapsedTime,
+                &SortDirection::Ascending
+            ),
+            vec![2, 1, 3]
+        );
+    }
+
+    /// A run with no clear time to show sorts last rather than first. The list
+    /// renders both the placeholder and a missing time as "-", and a column of
+    /// dashes at the top of "fastest first" answers the opposite of what was
+    /// asked. Among themselves they fall back to time, the list's resting
+    /// order — untimed rows in an arbitrary order would shuffle between pages.
+    #[test]
+    fn logs_without_a_real_in_game_time_sort_last() {
+        let conn = db_with(&[(1, false), (2, false), (3, false)]);
+        // Log 1 stored the placeholder; log 2 never recorded a time at all.
+        igt(&conn, &[(1, 1), (3, 100)]);
+
+        assert_eq!(
+            sorted(
+                &conn,
+                &SortType::QuestElapsedTime,
+                &SortDirection::Ascending
+            ),
+            vec![3, 1, 2]
+        );
+    }
+
+    /// Duration ranks a chain the same way: by the run that would come first on
+    /// its own. Wall-clock has no placeholder to exclude — every log has one.
+    #[test]
+    fn a_duration_sort_places_a_chain_by_its_fastest_run() {
+        let conn = db_with(&[(1, false), (2, false), (3, false)]);
+        chain(&conn, 1, &[3]);
+        durations(&conn, &[(1, 300), (2, 200), (3, 100)]);
+
+        assert_eq!(
+            sorted(&conn, &SortType::Duration, &SortDirection::Ascending),
+            vec![3, 1, 2]
+        );
     }
 }

--- a/src-tauri/src/db/logs.rs
+++ b/src-tauri/src/db/logs.rs
@@ -434,7 +434,7 @@ pub fn get_logs(
         )
         .build_rusqlite(SqliteQueryBuilder);
 
-    let mut stmt = conn.prepare(&sql).unwrap();
+    let mut stmt = conn.prepare(&sql)?;
     let params = values.as_params();
 
     let rows = stmt
@@ -464,7 +464,11 @@ pub fn get_logs(
         })
         .collect::<rusqlite::Result<Vec<LogEntry>>>();
 
-    let mut rows = rows.unwrap_or_default();
+    // Raised, not swallowed. An empty page is indistinguishable from a page
+    // whose filters matched nothing, so a decode failure here used to read as
+    // "no such logs" while the pager — sized by `get_counts`, which does raise
+    // — went on offering the pages it drew from.
+    let mut rows = rows?;
 
     // Put the chains back in the order the page query chose — by their most
     // recent run — and keep each chain's runs together. The row query can only

--- a/src-tauri/src/legality/mod.rs
+++ b/src-tauri/src/legality/mod.rs
@@ -44,7 +44,12 @@ pub const EMPTY_ID: u32 = game_reader::EMPTY_KEY;
 /// the sweep revisit logs already stamped 5 and WITHDRAW the verdicts it now
 /// declines to make. Without it the cutoff would only ever govern logs nobody
 /// had judged yet, i.e. nothing already in the database.
-pub const RULES_VERSION: u32 = 7;
+/// 8: wrightstones gained a trait-MEMBERSHIP rule ([`Rule::WrightstoneTrait`]),
+/// Immortal Shell joined the single-trait sigils, and the perfect-summon report
+/// moved from two to three. The first two accuse builds nobody was accusing
+/// before and the third WITHDRAWS a report from every two-perfect player in the
+/// database, so all three need the sweep to revisit already-judged logs.
+pub const RULES_VERSION: u32 = 8;
 
 /// Encounters recorded before this are never audited: epoch millis for
 /// 2026-07-09T00:00:00Z, inclusive (a log stamped exactly this is judged).
@@ -126,6 +131,14 @@ pub enum Rule {
     /// (primary, secondary1, secondary2) — index, not sorted rank, is what
     /// each level is checked against.
     WrightstoneTraitLevel,
+    /// A trait engraved on a wrightstone that no stone config can produce —
+    /// a sigil-only trait on a stone.
+    ///
+    /// Judged against the union of every transmarvel config's reachable
+    /// traits, which is the same table the ceilings come from. A 875-log
+    /// census found 6 off-pool readings in 4908, belonging to 2 of 87 players
+    /// and both carrying a whole stone of them — see `legality_stone_probe`.
+    WrightstoneTrait,
     /// A sigil carrying BOTH traits with a level above its own ceiling
     /// (default 15; raised only where the table declares it).
     SigilTraitLevel,
@@ -525,15 +538,17 @@ mod tests {
     ///   never reach the threshold, and the reachability case below would pass
     ///   without the rule ever judging a magnitude. It is the overmastery twin
     ///   of Behemoth's deliberately-unmaxed bonus below.
-    /// * **Summons** — Lucilius `6e5968fc` and Behemoth III `e4b7dcf9`, both
-    ///   `rolled: true`, both on the perfect-count WATCH LIST, each carrying
-    ///   a genuine candidate of its own lots: Lucilius main `5c862e13` (Gamma,
-    ///   window 11-15) with bonus `9245dfa4`, Behemoth III main `b5ff9fd3`
-    ///   (Uplift, 11-15) with bonus `a3539fbb`. Lucilius sits at the TOP of
-    ///   both windows on purpose: ONE perfect summon is legal and unreported
-    ///   (42 of 72 census players own one). Behemoth deliberately sits one step
-    ///   below its bonus top (8 of 9) so the perfect COUNT stays at one and the
-    ///   >=2 report must stay quiet — the summon twin of Stun's
+    /// * **Summons** — Lucilius `6e5968fc`, Behemoth III `e4b7dcf9`, Beelzebub
+    ///   `a7eff558` and Lilith `dfab70b7`, all `rolled: true`, all on the
+    ///   perfect-count WATCH LIST, each carrying a genuine candidate of its own
+    ///   lots: Lucilius main `5c862e13` (Gamma, window 11-15) with bonus
+    ///   `9245dfa4`, Behemoth III main `b5ff9fd3` (Uplift, 11-15) with bonus
+    ///   `a3539fbb`, Beelzebub main `dc584f60` (DMG Cap, 11-15) and Lilith main
+    ///   `71f11a9b` (Tyranny, 11-15), both with bonus `9245dfa4`. Three of them
+    ///   sit at the TOP of both windows on purpose: three perfect summons are
+    ///   legal and unreported. Behemoth deliberately sits one step below its
+    ///   bonus top (8 of 9) so the perfect COUNT stays at three and the >=4
+    ///   report must stay quiet — the summon twin of Stun's
     ///   deliberately-unmaxed overmastery above.
     ///
     ///   Both bonuses are Damage Cap Ups and both mains are on 11-15 curves,
@@ -605,6 +620,20 @@ mod tests {
                     main_trait_level: 15,
                     bonus_id: 0xa353_9fbb,
                     bonus_level: 8,
+                },
+                EquippedSummon {
+                    summon_id: 0xa7ef_f558,
+                    main_trait_id: 0xdc58_4f60,
+                    main_trait_level: 15,
+                    bonus_id: 0x9245_dfa4,
+                    bonus_level: 9,
+                },
+                EquippedSummon {
+                    summon_id: 0xdfab_70b7,
+                    main_trait_id: 0x71f1_1a9b,
+                    main_trait_level: 15,
+                    bonus_id: 0x9245_dfa4,
+                    bonus_level: 9,
                 },
             ],
             weapon_state: Some(WeaponState {
@@ -704,7 +733,7 @@ mod tests {
     /// proving the rule saw the fixture's data and judged it rather than
     /// skipping it as unreadable.
     ///
-    /// All ten rules, so the guard covers the whole module and not merely
+    /// All thirteen rules, so the guard covers the whole module and not merely
     /// one rule per file. One case worth reading closely: nudging the third
     /// Stun alone to the top of its ladder fires `OvermasteryAllMaxed`, which
     /// can only happen if the other two stun magnitudes were read, matched
@@ -718,6 +747,19 @@ mod tests {
         assert!(
             fires(&build, Rule::WrightstoneTraitLevel),
             "the level rule never judged the fixture's stone"
+        );
+
+        // Wrightstone: a SIGIL trait engraved on a stone. Level untouched, so
+        // this also proves the two stone rules are separable.
+        let mut build = legal_build();
+        stone(&mut build).wrightstone_traits[1].id = WAR_ELEMENTAL;
+        assert!(
+            fires(&build, Rule::WrightstoneTrait),
+            "the membership rule never judged the fixture's stone"
+        );
+        assert!(
+            !fires(&build, Rule::WrightstoneTraitLevel),
+            "a legal set of levels was accused"
         );
 
         // Sigils: an over-cap level on the two-trait sigil, a broken locked
@@ -801,10 +843,10 @@ mod tests {
             "the magnitude rule never judged the fixture's summons"
         );
 
-        // Nudging Behemoth's bonus alone to its top makes a SECOND perfect
-        // watched summon, which can only fire if Lucilius' top-of-window
-        // state was also read and recognised — the summon twin of the Stun
-        // case above.
+        // Nudging Behemoth's bonus alone to its top makes a FOURTH perfect
+        // watched summon, which can only fire if the other three's
+        // top-of-window state was also read and recognised — the summon twin
+        // of the Stun case above.
         let mut build = legal_build();
         build.summons[1].bonus_level = 9;
         assert!(
@@ -1050,6 +1092,7 @@ mod tests {
         accused.summons[1].bonus_level = 9;
         accused.sigils[0].first_trait_level = 30;
         masteries(&mut accused)[3].value = 0.7;
+        stone(&mut accused).wrightstone_traits[1].id = WAR_ELEMENTAL;
 
         // The third stun to the top of its ladder makes all three maxed;
         // Behemoth's bonus to the top of its window makes a second perfect
@@ -1072,8 +1115,9 @@ mod tests {
         assert_eq!(
             (RULES_VERSION, snapshot.join("\n").as_str()),
             (
-                7,
-                "SigilTraitLevel Sigil(0) Level(30) -> Level(15) odds=None\n\
+                8,
+                "WrightstoneTrait Wrightstone TraitId(1280871463) -> None odds=None\n\
+                 SigilTraitLevel Sigil(0) Level(30) -> Level(15) odds=None\n\
                  OvermasteryValue Overmastery(3) Amount(0.7) -> Amount(2.0) odds=None\n\
                  SummonBonusSource Summon(1) SummonBonusId(782879360) -> \
                  SummonIds([261648089, 789923164, 1851353340, 2237464972]) \
@@ -1081,8 +1125,7 @@ mod tests {
                  SummonBonusMagnitude Summon(1) Amount(75.0) -> Amount(50.0) odds=None\n\
                  OvermasteryAllMaxed Overmasteries Count(3) -> None \
                  odds=Some(2.2586109542631282e-9)\n\
-                 SummonPerfectCount Summons Count(2) -> None \
-                 odds=Some(2.4793388429752063e-8)"
+                 SummonPerfectCount Summons Count(4) -> None odds=None"
             ),
             "the rules changed what they say — update this snapshot AND bump \
              RULES_VERSION, or every stored log keeps the old verdicts forever"
@@ -1091,6 +1134,9 @@ mod tests {
 
     /// DMG Cap: a real trait, out of place everywhere the cases above use it.
     const DMG_CAP: u32 = 0xdc58_4f60;
+    /// War Elemental: a SIGIL trait, and one of the six the production census
+    /// caught on fabricated wrightstones. No stone config can produce it.
+    const WAR_ELEMENTAL: u32 = 0x4c58_8c27;
     /// The boss-set Healing Cap Up, granted by Rolan, Lucilius, Beelzebub and
     /// Lilith alone and reaching +75% where the standard set stops at +50%.
     const BOSS_SET_HEALING_CAP: u32 = 0x2ea9_ca80;

--- a/src-tauri/src/legality/sigils.rs
+++ b/src-tauri/src/legality/sigils.rs
@@ -203,10 +203,15 @@ fn quest_locked_homes() -> &'static HashMap<u32, HashSet<u32>> {
 }
 
 /// The sigils that can never carry a second trait, whatever the tables say
-/// about anything else: Stout Heart and Stout Heart+. A user-confirmed game
-/// rule — deliberately NOT the whole `SecondTrait::Nothing` class, whose 514
-/// gem.tbl rows are untrusted.
-pub const SINGLE_TRAIT_SIGILS: [u32; 2] = [0xcb5f29c1, 0x26ddcd39];
+/// about anything else: Stout Heart, Stout Heart+ and Immortal Shell. A
+/// user-confirmed game rule — deliberately NOT the whole `SecondTrait::Nothing`
+/// class, whose 514 gem.tbl rows are untrusted.
+///
+/// Immortal Shell**+** is deliberately absent, and generalising from its base
+/// sigil to the pair (as Stout Heart's two ids invite) accuses every honest
+/// owner: the + fixes a crab trait as its second, so carrying two traits is its
+/// normal state.
+pub const SINGLE_TRAIT_SIGILS: [u32; 3] = [0xcb5f29c1, 0x26ddcd39, 0x49434696];
 
 /// The four sigil rules. Empty slots and sigil ids the table does not know
 /// are skipped entirely.
@@ -347,6 +352,9 @@ mod tests {
     const STOUT_HEART_TRAIT: u32 = 0xa1a8_e39d;
     const STOUT_HEART_PLUS_SIGIL: u32 = 0x26dd_cd39;
     const STOUT_HEART_PLUS_TRAIT: u32 = 0xcac6_aff2;
+    /// The + is a different animal from the base sigil above: it FIXES a crab
+    /// trait as its second.
+    const IMMORTAL_SHELL_PLUS_SIGIL: u32 = 0x66cb_28ba;
 
     // ---- Production counter-examples, all four from the user's own logs ----
     /// Damage Cap V+ `b0cb5c64`, trait1 DMG Cap. gem.tbl's `+0x04` column reads
@@ -594,6 +602,51 @@ mod tests {
             assert_eq!(findings[0].rule, Rule::SigilSingleTraitOnly);
             assert_eq!(findings[0].observed, Value::TraitId(STEADY_FOCUS));
         }
+    }
+
+    /// Immortal Shell holds one trait, exactly as Stout Heart does
+    /// (user-confirmed 2026-08-03).
+    #[test]
+    fn immortal_shell_can_never_carry_a_second_trait() {
+        let trait1 = stock_sigils()[&IMMORTAL_SHELL_SIGIL].trait1;
+
+        assert_eq!(
+            audit_sigils(&[sigil(IMMORTAL_SHELL_SIGIL, (trait1, 15), (0, 0))]),
+            vec![]
+        );
+
+        let findings = audit_sigils(&[sigil(
+            IMMORTAL_SHELL_SIGIL,
+            (trait1, 15),
+            (STEADY_FOCUS, 10),
+        )]);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule, Rule::SigilSingleTraitOnly);
+        assert_eq!(findings[0].observed, Value::TraitId(STEADY_FOCUS));
+    }
+
+    /// THE TRAP the base sigil sets for this rule.
+    ///
+    /// Immortal Shell+ is NOT single-trait: the table fixes a crab trait as its
+    /// second, so every legitimate owner carries two. Adding the + id alongside
+    /// the base one — the shape Stout Heart has, and the obvious generalisation
+    /// — accuses all of them.
+    #[test]
+    fn immortal_shell_plus_legitimately_carries_its_fixed_second_trait() {
+        let entry = &stock_sigils()[&IMMORTAL_SHELL_PLUS_SIGIL];
+        let SecondTrait::Fixed(fixed) = entry.second else {
+            panic!("Immortal Shell+ fixes a second trait");
+        };
+
+        assert!(!SINGLE_TRAIT_SIGILS.contains(&IMMORTAL_SHELL_PLUS_SIGIL));
+        assert_eq!(
+            audit_sigils(&[sigil(
+                IMMORTAL_SHELL_PLUS_SIGIL,
+                (entry.trait1, 20),
+                (fixed, 20)
+            )]),
+            vec![]
+        );
     }
 
     /// The Stout Heart ids and the table agree these sigils take no second

--- a/src-tauri/src/legality/summons.rs
+++ b/src-tauri/src/legality/summons.rs
@@ -40,21 +40,24 @@
 //!
 //! * A single perfect summon is ordinary — 42 of 72 real players in the
 //!   production census own at least one (the rarest single config is only
-//!   1 in 18,333, and a confirmed-legitimate player owns it). The rule
-//!   therefore only speaks at two or more, where 26 of 72 stood at census
-//!   time — the user chose to see that list, knowing its size.
+//!   1 in 18,333, and a confirmed-legitimate player owns it). Two is not
+//!   remarkable either: 26 of 72 stood there at census time, better than a
+//!   third of everyone owning any. The rule therefore only speaks at FOUR or
+//!   more (user-raised 2026-08-03, from an original threshold of two).
 //! * Guaranteed-variant summons (`rolled: false`) are excluded: their fixed
 //!   config is a probability-1 drop, not a roll.
 //! * A bonus outside this summon's own lots does not count as perfect — its
 //!   window is unknown, so it cannot be "top". That keeps a modded summon
-//!   from inflating a probability the report would then price as if it had
-//!   been rolled.
-//! * The reported odds are the product of each counted summon's single-draw
-//!   config probability. That is the honest table price of the draws, but it
-//!   OVERSTATES rarity for a farmer who rolls hundreds of times and equips
-//!   the best — which is exactly why this rule reports rather than accuses.
-//!   The odds the UI prints beside it are what carries that distinction to a
-//!   reader now that findings no longer carry a severity.
+//!   from inflating the count.
+//! * The COUNT is the whole claim. This used to multiply each counted
+//!   summon's single-draw config probability into an `odds`, but that price
+//!   is honest only about draws and knowingly blind to a farmer who rolls
+//!   hundreds of times and equips the best — so it measured something nobody
+//!   was asking about. Removed 2026-08-03 (user); the finding carries no odds
+//!   and no surface prints a probability for it.
+//! * Summons are counted per EQUIPPED SLOT, not per distinct id: four copies
+//!   of one perfect Lucilius is the most obviously fabricated set there is,
+//!   and deduplicating by id would reduce it to a count of one.
 //!
 //! # Why levels are deliberately NOT judged, but magnitudes are
 //!
@@ -85,9 +88,12 @@ use super::{
 /// One candidate of a summon's main-trait or equip-bonus lot, as generated.
 #[derive(Debug, Clone, Deserialize)]
 struct RawCandidate {
-    /// This candidate's share of its lot's total weight.
-    weight: u32,
     /// `(level, weight)` pairs, ascending.
+    ///
+    /// The generated file also carries the candidate's own pick weight. It is
+    /// not read: nothing judges or prices how likely a candidate was to be
+    /// drawn, only whether its level sits at the top of its window, and serde
+    /// drops the unlisted field for us.
     levels: Vec<(u32, u32)>,
 }
 
@@ -102,10 +108,14 @@ struct RawEntry {
     bonuses: HashMap<String, RawCandidate>,
 }
 
-/// One candidate's share of its lot and its level curve.
+/// One candidate's level curve.
+///
+/// The candidate's own pick weight is deliberately not kept: nothing judges or
+/// prices how likely a candidate was to be drawn, only whether the level sits
+/// at the top of its window. It stays on [`RawCandidate`] because the generated
+/// file carries it.
 #[derive(Debug, Clone)]
 pub struct Candidate {
-    weight: u32,
     levels: Vec<(u32, u32)>,
 }
 
@@ -143,54 +153,6 @@ impl Lot {
             .find(|&&(_, weight)| weight > 0)
             .map(|&(level, _)| level)
     }
-
-    /// The top of a candidate's level window, but only where landing on it was
-    /// a ROLL. `None` when the candidate's window holds a single level: the top
-    /// is then also the floor, and it lands there with certainty.
-    ///
-    /// Every rolled watched boss offers five ordinary main traits on an 11-15
-    /// curve plus one "special" on a singleton curve at level 15 — War
-    /// Elemental (Rolan, Lilith), Berserker Echo (Lucilius), Spartan Echo
-    /// (Beelzebub), Stout Heart (Behemoth III, Vrazarek). A special is at the
-    /// top of its window the instant it drops, so counting it as a perfect roll
-    /// prices certainty as luck.
-    ///
-    /// Distinct from [`Lot::top_level`], which the magnitude ceiling still
-    /// wants: a ceiling is about what a summon CAN display, and a fixed-level
-    /// candidate displays its magnitude just as surely as a rolled one.
-    pub fn rolled_top_level(&self, id: u32) -> Option<u32> {
-        let candidate = self.candidates.get(&id)?;
-        let mut live = candidate
-            .levels
-            .iter()
-            .filter(|&&(_, weight)| weight > 0)
-            .map(|&(level, _)| level);
-        // Levels are ascending, so the last live one is the top — and reaching
-        // `last` at all proves a second level existed to have rolled instead.
-        live.next()?;
-        live.last()
-    }
-
-    /// Probability of ONE roll of this lot landing exactly `(id, level)`.
-    /// `None` when the outcome is off-table or the table degenerates (zero
-    /// total weight) — a price it cannot state must not be stated as zero.
-    pub fn config_odds(&self, id: u32, level: u32) -> Option<f64> {
-        let candidate = self.candidates.get(&id)?;
-        let level_weight = candidate
-            .levels
-            .iter()
-            .find(|&&(step, _)| step == level)
-            .map(|&(_, weight)| weight)?;
-        let lot_total: u64 = self.candidates.values().map(|c| u64::from(c.weight)).sum();
-        let level_total: u64 = candidate.levels.iter().map(|&(_, w)| u64::from(w)).sum();
-        if lot_total == 0 || level_total == 0 || level_weight == 0 {
-            return None;
-        }
-        Some(
-            (f64::from(candidate.weight) / lot_total as f64)
-                * (f64::from(level_weight) / level_total as f64),
-        )
-    }
 }
 
 /// The acquisition roll space of one summon.
@@ -211,7 +173,6 @@ fn build_lot(raw: HashMap<String, RawCandidate>) -> Lot {
             Some((
                 parse_hex(&id)?,
                 Candidate {
-                    weight: candidate.weight,
                     levels: candidate.levels,
                 },
             ))
@@ -381,41 +342,37 @@ fn summon_rules() -> &'static SummonRules {
 }
 
 /// How many perfect summons an equipped set must carry before the count is
-/// reported. One is ordinary (42 of 72 census players own one); the user set
-/// the reporting threshold at two.
-pub const PERFECT_SUMMON_FLAG_COUNT: usize = 2;
+/// reported. One is ordinary (42 of 72 census players own one), and two is
+/// common enough to be unremarkable (26 of 72 — better than a third of the
+/// players who own any). The user raised the threshold from two to four on
+/// 2026-08-03.
+pub const PERFECT_SUMMON_FLAG_COUNT: usize = 4;
 
-/// The single-draw price of this summon's exact config, or `None` when the
-/// summon does not count as "perfect": a guaranteed variant (its fixed config
-/// is a probability-1 drop, not a roll), a bonus granting an effect nobody
-/// farms for, a slot below the top of its window, a slot whose window holds
-/// only one level, or a trait/bonus outside the summon's own lots (its window
-/// is unknown).
-fn perfect_config_odds(entry: &SummonEntry, summon: &EquippedSummon) -> Option<f64> {
+/// Whether this summon counts as "perfect": both slots at the top of their
+/// windows in the summon's OWN lots, with a bonus granting an effect players
+/// actually chase.
+///
+/// False for a guaranteed variant (its fixed config is a probability-1 drop,
+/// not a roll), a bonus granting an effect nobody farms for, a slot below the
+/// top of its window, or a trait/bonus outside the summon's own lots — whose
+/// window is unknown, so "top" is unknowable and a modded summon cannot inflate
+/// the count.
+///
+/// A single-level ("special") main DOES count, and needs no special case to:
+/// its top level is simply the only level it has.
+fn is_perfect(entry: &SummonEntry, summon: &EquippedSummon) -> bool {
     if !entry.rolled {
-        return None;
+        return false;
     }
     // Perfection is only interesting about a stat a player would reroll for
     // (see `chased_effects`) — a maxed Healing Cap Up is a coincidence, not a
-    // farm. The main trait is scoped by its window instead: its namespace has
-    // no notion of these effects, and `rolled_top_level` below is what keeps
-    // the certainty-shaped mains out.
+    // farm. The main trait carries no such scope: its namespace has no notion
+    // of these effects, so its own window is all there is to judge it by.
     if !summon_bonus_values::effect_of(summon.bonus_id).is_some_and(chased_effects::is_chased) {
-        return None;
+        return false;
     }
-    if entry.main_traits.rolled_top_level(summon.main_trait_id)? != summon.main_trait_level {
-        return None;
-    }
-    if entry.bonuses.rolled_top_level(summon.bonus_id)? != summon.bonus_level {
-        return None;
-    }
-    let main = entry
-        .main_traits
-        .config_odds(summon.main_trait_id, summon.main_trait_level)?;
-    let bonus = entry
-        .bonuses
-        .config_odds(summon.bonus_id, summon.bonus_level)?;
-    Some(main * bonus)
+    entry.main_traits.top_level(summon.main_trait_id) == Some(summon.main_trait_level)
+        && entry.bonuses.top_level(summon.bonus_id) == Some(summon.bonus_level)
 }
 
 /// The highest magnitude any bonus of `effect` can display on a summon of this
@@ -527,28 +484,28 @@ pub fn audit_summons(summons: &[EquippedSummon]) -> Vec<Finding> {
     }
 
     // The perfect-count report (see the module docs). Only the watched boss
-    // summons are counted; the odds multiply the counted summons' single-draw
-    // prices — the honest table price of the draws, knowingly blind to
-    // farming, which is why this is Improbable.
-    let perfect: Vec<f64> = summons
+    // summons are counted.
+    let perfect = summons
         .iter()
         .filter(|summon| rules.perfect_watched.contains(&summon.summon_id))
-        .filter_map(|summon| {
+        .filter(|summon| {
             stock_summons()
                 .get(&summon.summon_id)
-                .and_then(|entry| perfect_config_odds(entry, summon))
+                .is_some_and(|entry| is_perfect(entry, summon))
         })
-        .collect();
+        .count();
 
-    if perfect.len() >= PERFECT_SUMMON_FLAG_COUNT {
+    if perfect >= PERFECT_SUMMON_FLAG_COUNT {
         findings.push(Finding {
             rule: Rule::SummonPerfectCount,
             subject: Subject::Summons,
-            observed: Value::Count(perfect.len()),
-            // Nothing is exceeded: the set is legal, merely improbable, so
-            // `odds` is the payload (the `OvermasteryAllMaxed` idiom).
+            observed: Value::Count(perfect),
+            // Nothing is exceeded: the set is legal, merely remarkable. The
+            // COUNT is the whole claim — this used to multiply the counted
+            // summons' single-draw prices into an `odds`, which nothing shows
+            // any more (user, 2026-08-03).
             allowed: Value::None,
-            odds: Some(perfect.iter().product()),
+            odds: None,
             evidence: None,
         });
     }
@@ -589,10 +546,40 @@ mod tests {
     /// Healing Cap 6-9 on Behemoth III.
     const LUCILIUS_ROLLED: u32 = 0x6e59_68fc;
     const ALPHA: u32 = 0xdbe1_d775;
+    const GAMMA: u32 = 0x5c86_2e13;
     const LUCILIUS_NA_DMG_CAP: u32 = 0x9245_dfa4;
     const BEHEMOTH_III_ROLLED: u32 = 0xe4b7_dcf9;
     const UPLIFT: u32 = 0xb5ff_9fd3;
     const BEHEMOTH_BONUS: u32 = 0xa353_9fbb;
+    /// The other watched bosses the count report needs now that it starts at
+    /// four. Every trait and bonus used with them below is in their own lots,
+    /// so the configs are legal as well as perfect.
+    const BEELZEBUB_ROLLED: u32 = 0xa7ef_f558;
+    const LILITH_ROLLED: u32 = 0xdfab_70b7;
+    const ROLAN_ROLLED: u32 = 0x0f98_6ed9;
+    const TYRANNY: u32 = 0x71f1_1a9b;
+
+    /// PADDING for the "X does not count as perfect" tests below, which each
+    /// need the set to sit exactly one counted summon short of the threshold.
+    ///
+    /// Without it those tests lose their teeth the moment the threshold rises:
+    /// a set holding one perfect summon beside the thing under test stays
+    /// silent whether or not the rule wrongly counts it, so the assertion
+    /// passes for the wrong reason. Padded to three, the test fires the instant
+    /// X is counted. Deliberately Beelzebub, Lilith and Rolan — the tests below
+    /// use Lucilius and Behemoth III, and a repeated id would be counted twice
+    /// and blow the budget these exist to hold.
+    fn perfect_beelzebub() -> EquippedSummon {
+        summon(BEELZEBUB_ROLLED, (DMG_CAP, 15), (BOSS_SET_NA_DMG_CAP, 9))
+    }
+
+    fn perfect_lilith() -> EquippedSummon {
+        summon(LILITH_ROLLED, (TYRANNY, 15), (BOSS_SET_NA_DMG_CAP, 9))
+    }
+
+    fn perfect_rolan() -> EquippedSummon {
+        summon(ROLAN_ROLLED, (UPLIFT, 15), (BOSS_SET_NA_DMG_CAP, 9))
+    }
 
     /// Two of the eleven boss-only equip bonuses, granted by Rolan, Lucilius,
     /// Beelzebub and Lilith alone. `2ea9ca80` reaches Healing Cap Up +75%
@@ -831,26 +818,55 @@ mod tests {
         assert_eq!(audit_summons(&equipped), vec![]);
     }
 
-    /// The user-requested report: two perfect watched bosses together are
-    /// worth a row. Improbable with the multiplied single-draw price — never
-    /// proof.
+    /// THE BOUNDARY. Three is silent (user-raised 2026-08-03): 26 of 72 census
+    /// players stood at two, which is a quarter of the database reported for
+    /// what a determined farmer reaches, so the threshold moved to four and the
+    /// report names only the builds that are genuinely remarkable.
     #[test]
-    fn two_perfect_watched_summons_are_reported_as_improbable() {
+    fn three_perfect_watched_summons_are_not_reported() {
         let equipped = [
             summon(LUCILIUS_ROLLED, (ALPHA, 15), (LUCILIUS_NA_DMG_CAP, 9)),
             summon(BEHEMOTH_III_ROLLED, (UPLIFT, 15), (BEHEMOTH_BONUS, 9)),
+            perfect_beelzebub(),
+        ];
+        assert_eq!(audit_summons(&equipped), vec![]);
+    }
+
+    /// The user-requested report: four perfect watched bosses together are
+    /// worth a row. A COUNT and nothing else — never proof.
+    #[test]
+    fn four_perfect_watched_summons_are_reported() {
+        let equipped = [
+            summon(LUCILIUS_ROLLED, (ALPHA, 15), (LUCILIUS_NA_DMG_CAP, 9)),
+            summon(BEHEMOTH_III_ROLLED, (UPLIFT, 15), (BEHEMOTH_BONUS, 9)),
+            perfect_beelzebub(),
+            perfect_lilith(),
         ];
         let findings = audit_summons(&equipped);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].rule, Rule::SummonPerfectCount);
         assert_eq!(findings[0].subject, Subject::Summons);
-        assert_eq!(findings[0].observed, Value::Count(2));
+        assert_eq!(findings[0].observed, Value::Count(4));
         assert_eq!(findings[0].allowed, Value::None);
-        let odds = findings[0].odds.expect("the odds are the payload");
-        assert!(
-            odds > 0.0 && odds < 1e-4,
-            "odds {odds} should be tiny but non-zero"
-        );
+        // The count is the whole claim; no probability is computed or shown.
+        assert_eq!(findings[0].odds, None);
+    }
+
+    /// FOUR OF THE SAME SUMMON (user, 2026-08-03): the same Lucilius, the same
+    /// Gamma, the same maxed Normal Attack Damage Cap Up, four times over.
+    ///
+    /// The count is over EQUIPPED SLOTS, not distinct summon ids, and this is
+    /// the shape that would slip through a rule that deduplicated by id — the
+    /// most obviously fabricated set there is, reduced to a count of one.
+    #[test]
+    fn four_copies_of_one_perfect_summon_are_still_reported() {
+        let lucilius = || summon(LUCILIUS_ROLLED, (GAMMA, 15), (LUCILIUS_NA_DMG_CAP, 9));
+        let equipped = [lucilius(), lucilius(), lucilius(), lucilius()];
+
+        let findings = audit_summons(&equipped);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule, Rule::SummonPerfectCount);
+        assert_eq!(findings[0].observed, Value::Count(4));
     }
 
     /// The display names of some summon ids, read from the same lang file the
@@ -924,30 +940,55 @@ mod tests {
         assert_eq!(owners.len(), 4, "expected four names, got {owners:?}");
     }
 
-    /// THE SPECIAL-CANDIDATE GUARD (user, 2026-07-30).
+    /// THE SPECIAL CANDIDATES (user-reversed 2026-08-03).
     ///
     /// Every rolled watched boss offers five ordinary main traits on an 11-15
     /// curve plus ONE "special" pinned to a single-level curve at 15 (War
     /// Elemental on Rolan and Lilith, Berserker Echo on Lucilius, Spartan Echo
-    /// on Beelzebub, Stout Heart on Behemoth III and Vrazarek). A special is at
-    /// "the top of its window" the instant it drops — there is no other level
-    /// it could have taken — so calling that a perfect roll prices certainty as
-    /// though it were luck.
+    /// on Beelzebub, Stout Heart on Behemoth III and Vrazarek).
+    ///
+    /// These were excluded from 2026-07-30 to 2026-08-03, on the reasoning that
+    /// a level which could not have been anything else is certainty rather than
+    /// luck. That left a hole: three specials beside three maxed chased bonuses
+    /// could never be reported however deliberate the build. They now count,
+    /// and no arithmetic was added to make it work — a single-level candidate's
+    /// config odds are already just its draw weight.
     #[test]
-    fn a_main_trait_that_can_only_ever_be_fifteen_is_not_a_perfect_roll() {
+    fn a_main_trait_that_can_only_ever_be_fifteen_still_counts() {
         let equipped = [
             summon(
                 LUCILIUS_ROLLED,
                 (BERSERKER_ECHO, 15),
                 (LUCILIUS_NA_DMG_CAP, 9),
             ),
-            summon(BEHEMOTH_III_ROLLED, (UPLIFT, 15), (BEHEMOTH_BONUS, 9)),
+            perfect_beelzebub(),
+            perfect_lilith(),
+            perfect_rolan(),
         ];
-        assert_eq!(
-            audit_summons(&equipped),
-            vec![],
-            "a single-level main trait was counted as a perfect roll"
-        );
+        let findings = audit_summons(&equipped);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule, Rule::SummonPerfectCount);
+        assert_eq!(findings[0].observed, Value::Count(4));
+    }
+
+    /// A special main and an ordinary maxed one are the same claim now: the
+    /// report counts summons and states nothing about how likely the set was.
+    #[test]
+    fn a_special_main_reads_the_same_as_an_ordinary_maxed_one() {
+        let report_for = |main: u32| {
+            let equipped = [
+                summon(LUCILIUS_ROLLED, (main, 15), (LUCILIUS_NA_DMG_CAP, 9)),
+                perfect_beelzebub(),
+                perfect_lilith(),
+                perfect_rolan(),
+            ];
+            audit_summons(&equipped)
+                .into_iter()
+                .find(|finding| finding.rule == Rule::SummonPerfectCount)
+                .expect("three perfect summons are reported")
+        };
+
+        assert_eq!(report_for(BERSERKER_ECHO), report_for(ALPHA));
     }
 
     /// The same trait on an ordinary multi-level curve still counts — the guard
@@ -958,6 +999,8 @@ mod tests {
         let equipped = [
             summon(LUCILIUS_ROLLED, (ALPHA, 15), (LUCILIUS_NA_DMG_CAP, 9)),
             summon(BEHEMOTH_III_ROLLED, (UPLIFT, 15), (BEHEMOTH_BONUS, 9)),
+            perfect_beelzebub(),
+            perfect_lilith(),
         ];
         assert!(
             audit_summons(&equipped)
@@ -977,6 +1020,9 @@ mod tests {
         let equipped = [
             summon(LUCILIUS_ROLLED, (ALPHA, 15), (BOSS_SET_HEALING_CAP, 9)),
             summon(BEHEMOTH_III_ROLLED, (UPLIFT, 15), (STANDARD_HEALING_CAP, 9)),
+            perfect_beelzebub(),
+            perfect_lilith(),
+            perfect_rolan(),
         ];
         assert_eq!(
             audit_summons(&equipped),
@@ -997,6 +1043,9 @@ mod tests {
                 (CRIT_RATE_UP, 9),
             ),
             summon(GOLDSLIME_III, (GOLDSLIME_MAIN, 15), (GOLDSLIME_BONUS, 9)),
+            perfect_beelzebub(),
+            perfect_lilith(),
+            perfect_rolan(),
         ];
         assert_eq!(audit_summons(&equipped), vec![]);
     }
@@ -1068,6 +1117,8 @@ mod tests {
         let equipped = [
             summon(VRAZAREK_III, (DMG_CAP, 15), (VRAZAREK_BONUS, 4)),
             summon(LUCILIUS_ROLLED, (ALPHA, 15), (LUCILIUS_NA_DMG_CAP, 9)),
+            perfect_beelzebub(),
+            perfect_lilith(),
         ];
         assert_eq!(
             audit_summons(&equipped),
@@ -1088,6 +1139,8 @@ mod tests {
                     (LUCILIUS_NA_DMG_CAP, bonus_level),
                 ),
                 summon(BEHEMOTH_III_ROLLED, (UPLIFT, 15), (BEHEMOTH_BONUS, 9)),
+                perfect_beelzebub(),
+                perfect_lilith(),
             ];
             assert_eq!(
                 audit_summons(&equipped),
@@ -1111,6 +1164,8 @@ mod tests {
         let equipped = [
             summon(BEHEMOTH_III_ROLLED, (UPLIFT, 15), (BOSS_SET_HEALING_CAP, 9)),
             summon(LUCILIUS_ROLLED, (ALPHA, 15), (LUCILIUS_NA_DMG_CAP, 9)),
+            perfect_beelzebub(),
+            perfect_lilith(),
         ];
         let findings = audit_summons(&equipped);
         assert!(

--- a/src-tauri/src/legality/wrightstone.rs
+++ b/src-tauri/src/legality/wrightstone.rs
@@ -12,11 +12,13 @@
 //! stones from other sources — accusing a stone for its primary trait would
 //! rest on a table that does not claim to cover it.
 
+use std::collections::HashSet;
+
 use protocol::WeaponState;
 
 use crate::transmarvel;
 
-use super::{Finding, Rule, Subject, Value};
+use super::{is_empty, Finding, Rule, Subject, Value};
 
 /// Highest level any weight row permits: index `n` carries level `n + 1`.
 /// `None` when the lot grants no level at all.
@@ -79,6 +81,49 @@ pub fn stock_slot_ceilings() -> [u32; 3] {
     })
 }
 
+/// Every trait a wrightstone can be engraved with: the four family primaries,
+/// everything reachable through each config's `type_row`, and any slot a config
+/// fixes outright.
+///
+/// Resolved in the two steps the tables require — the `type_row` id selects a
+/// row of `(lot hash, weight)` options in `skill_type_rows`, and each lot hash
+/// then keys `skill_lots` for the traits. Looking the small id up in
+/// `skill_lots` directly always misses.
+pub fn stock_trait_pool() -> &'static HashSet<u32> {
+    static POOL: std::sync::OnceLock<HashSet<u32>> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        let tables = transmarvel::stock_tables();
+        let mut pool = HashSet::new();
+
+        for config in tables.stone_configs.values() {
+            pool.insert(config.trait1);
+
+            if let Some(options) = tables.skill_type_rows.get(&config.type_row) {
+                for &(lot_hash, _weight) in options {
+                    if let Some(traits) = tables.skill_lots.get(&lot_hash) {
+                        pool.extend(traits.iter().copied());
+                    }
+                }
+            }
+
+            for slot in &config.slots {
+                if slot.skill != 0 {
+                    pool.insert(slot.skill);
+                }
+            }
+        }
+
+        // An empty pool would permit nothing and accuse everyone. The tables are
+        // baked into the binary, so this is schema drift rather than absent live
+        // data, and it must fail loudly rather than silently accuse.
+        assert!(
+            !pool.is_empty(),
+            "no wrightstone traits resolved from the transmarvel tables"
+        );
+        pool
+    })
+}
+
 /// The game engraves exactly three traits on a wrightstone. A shorter list is
 /// a partial remote read, not a shorter stone.
 const STONE_TRAIT_COUNT: usize = 3;
@@ -109,18 +154,43 @@ pub fn audit_wrightstone(state: Option<&WeaponState>) -> Vec<Finding> {
         .zip(ceilings)
         .any(|(pair, ceiling)| pair.level > ceiling);
 
-    if !over_ceiling {
-        return Vec::new();
+    let mut findings = Vec::new();
+
+    if over_ceiling {
+        findings.push(Finding {
+            rule: Rule::WrightstoneTraitLevel,
+            subject: Subject::Wrightstone,
+            observed: Value::Levels(state.wrightstone_traits.iter().map(|p| p.level).collect()),
+            allowed: Value::Levels(ceilings.to_vec()),
+            odds: None,
+            evidence: None,
+        });
     }
 
-    vec![Finding {
-        rule: Rule::WrightstoneTraitLevel,
-        subject: Subject::Wrightstone,
-        observed: Value::Levels(state.wrightstone_traits.iter().map(|p| p.level).collect()),
-        allowed: Value::Levels(ceilings.to_vec()),
-        odds: None,
-        evidence: None,
-    }]
+    // Membership, one finding per offending slot. The two modded stones in the
+    // census had all three slots fabricated, and one finding naming one trait
+    // would leave the other two unstated.
+    //
+    // `allowed` is deliberately `None`: the pool is 71 traits, and a list that
+    // long settles nothing a reader can check. The claim is the trait itself —
+    // a sigil trait on a stone.
+    let pool = stock_trait_pool();
+    findings.extend(
+        state
+            .wrightstone_traits
+            .iter()
+            .filter(|pair| !is_empty(pair.id) && !pool.contains(&pair.id))
+            .map(|pair| Finding {
+                rule: Rule::WrightstoneTrait,
+                subject: Subject::Wrightstone,
+                observed: Value::TraitId(pair.id),
+                allowed: Value::None,
+                odds: None,
+                evidence: None,
+            }),
+    );
+
+    findings
 }
 
 #[cfg(test)]
@@ -264,5 +334,86 @@ mod tests {
     #[test]
     fn stays_silent_on_a_partial_remote_read() {
         assert_eq!(audit_wrightstone(Some(&stone(&[(0xf372f096, 20)]))), vec![]);
+    }
+
+    /// War Elemental is a SIGIL trait. No wrightstone lot grants it, so a stone
+    /// carrying it is a stone the game could not have engraved.
+    #[test]
+    fn flags_a_trait_no_stone_can_carry() {
+        let state = stone(&[(0xf372f096, 20), (0x4c588c27, 15), (0x57ab5b10, 10)]);
+        let findings = audit_wrightstone(Some(&state));
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule, Rule::WrightstoneTrait);
+        assert_eq!(findings[0].subject, Subject::Wrightstone);
+        assert_eq!(findings[0].observed, Value::TraitId(0x4c588c27));
+        // The pool is 71 traits. Listing it would not settle anything a reader
+        // could check, so the claim is the trait itself.
+        assert_eq!(findings[0].allowed, Value::None);
+    }
+
+    /// One finding per off-pool trait: the two modded stones the census found
+    /// had all three slots fabricated, and collapsing that into a single
+    /// finding would name one trait and hide the other two.
+    #[test]
+    fn flags_every_off_pool_trait_on_the_stone() {
+        let state = stone(&[(0x3b71af12, 20), (0xaefeb1bc, 15), (0xfff8cf64, 10)]);
+        let observed: Vec<Value> = audit_wrightstone(Some(&state))
+            .into_iter()
+            .filter(|finding| finding.rule == Rule::WrightstoneTrait)
+            .map(|finding| finding.observed)
+            .collect();
+
+        assert_eq!(
+            observed,
+            vec![
+                Value::TraitId(0x3b71af12),
+                Value::TraitId(0xaefeb1bc),
+                Value::TraitId(0xfff8cf64),
+            ]
+        );
+    }
+
+    /// THE FALSE-ACCUSATION GUARD for the membership rule.
+    ///
+    /// Every trait the gacha configs can produce must pass. The pool is derived
+    /// from the same tables the ceilings are, so a stone the transmarvel itself
+    /// rolled can never be accused by this rule.
+    #[test]
+    fn accuses_nothing_the_gacha_can_roll() {
+        for &trait_id in stock_trait_pool() {
+            let state = stone(&[(trait_id, 20), (0xdc584f60, 15), (0x57ab5b10, 10)]);
+            let findings = audit_wrightstone(Some(&state));
+            assert!(
+                !findings.iter().any(|f| f.rule == Rule::WrightstoneTrait),
+                "trait {trait_id:08x} is in the gacha pool but was accused"
+            );
+        }
+    }
+
+    /// The two rules are separable: a stone can breach a ceiling with perfectly
+    /// ordinary traits, and carry an impossible trait at a legal level.
+    #[test]
+    fn judges_membership_and_level_independently() {
+        let over_cap = stone(&[(0xf372f096, 25), (0xdc584f60, 15), (0x57ab5b10, 10)]);
+        let rules: Vec<Rule> = audit_wrightstone(Some(&over_cap))
+            .iter()
+            .map(|f| f.rule)
+            .collect();
+        assert_eq!(rules, vec![Rule::WrightstoneTraitLevel]);
+
+        let off_pool = stone(&[(0xf372f096, 20), (0x4c588c27, 15), (0x57ab5b10, 10)]);
+        let rules: Vec<Rule> = audit_wrightstone(Some(&off_pool))
+            .iter()
+            .map(|f| f.rule)
+            .collect();
+        assert_eq!(rules, vec![Rule::WrightstoneTrait]);
+    }
+
+    /// An empty slot is missing data, never an impossible trait.
+    #[test]
+    fn never_accuses_an_empty_slot() {
+        let state = stone(&[(0xf372f096, 20), (0, 0), (super::super::EMPTY_ID, 0)]);
+        assert_eq!(audit_wrightstone(Some(&state)), vec![]);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1075,10 +1075,24 @@ fn fetch_logs(
     )
     .map_err(|e| e.to_string())?;
 
+    // Pages hold a fixed number of CHAINS, not of rows, so a Repeat Quest chain
+    // is never cut across a page boundary — see `page_chain_keys`. `log_count`
+    // still counts runs: it is the "N saved" figure, which is about the logs.
+    let chain_count = db::logs::get_chains_count(
+        &conn,
+        filter_by_enemy_id,
+        filter_by_quest_id,
+        quest_completed,
+        &filter_by_player_id,
+        &filter_by_player_character,
+        flagged_only,
+    )
+    .map_err(|e| e.to_string())?;
+
     let page_ids: Vec<i64> = logs.iter().map(|log| log.id()).collect();
     let legality = db::legality::findings_for_logs(&conn, &page_ids).map_err(|e| e.to_string())?;
 
-    let page_count = (log_count as f64 / per_page as f64).ceil() as u32;
+    let page_count = (chain_count as f64 / per_page as f64).ceil() as u32;
 
     let mut enemy_ids = Vec::new();
     let mut quest_ids = Vec::new();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1049,50 +1049,35 @@ fn fetch_logs(
         })
         .unwrap_or(db::logs::SortDirection::Descending);
 
+    let filters = db::logs::LogFilters {
+        enemy_id: filter_by_enemy_id,
+        quest_id: filter_by_quest_id,
+        cleared: quest_completed,
+        player_id: &filter_by_player_id,
+        player_character: &filter_by_player_character,
+        flagged_only,
+    };
+
     let logs = db::logs::get_logs(
         &conn,
-        filter_by_enemy_id,
-        filter_by_quest_id,
+        &filters,
         per_page,
         offset,
         &sort_type_param,
         &sort_direction_param,
-        quest_completed,
-        &filter_by_player_id,
-        &filter_by_player_character,
-        flagged_only,
     )
     .map_err(|e| e.to_string())?;
 
-    let log_count = db::logs::get_logs_count(
-        &conn,
-        filter_by_enemy_id,
-        filter_by_quest_id,
-        quest_completed,
-        &filter_by_player_id,
-        &filter_by_player_character,
-        flagged_only,
-    )
-    .map_err(|e| e.to_string())?;
-
-    // Pages hold a fixed number of CHAINS, not of rows, so a Repeat Quest chain
-    // is never cut across a page boundary — see `page_chain_keys`. `log_count`
-    // still counts runs: it is the "N saved" figure, which is about the logs.
-    let chain_count = db::logs::get_chains_count(
-        &conn,
-        filter_by_enemy_id,
-        filter_by_quest_id,
-        quest_completed,
-        &filter_by_player_id,
-        &filter_by_player_character,
-        flagged_only,
-    )
-    .map_err(|e| e.to_string())?;
+    let counts = db::logs::get_counts(&conn, &filters).map_err(|e| e.to_string())?;
+    let log_count = counts.logs;
 
     let page_ids: Vec<i64> = logs.iter().map(|log| log.id()).collect();
     let legality = db::legality::findings_for_logs(&conn, &page_ids).map_err(|e| e.to_string())?;
 
-    let page_count = (chain_count as f64 / per_page as f64).ceil() as u32;
+    // Pages hold a fixed number of CHAINS, not of rows, so a Repeat Quest chain
+    // is never cut across a page boundary — see `page_chain_keys`. `log_count`
+    // stays the run count: it is the "N saved" figure, which is about the logs.
+    let page_count = (counts.chains as f64 / per_page as f64).ceil() as u32;
 
     let mut enemy_ids = Vec::new();
     let mut quest_ids = Vec::new();

--- a/src/legality.test.ts
+++ b/src/legality.test.ts
@@ -153,26 +153,20 @@ describe("describeLimit", () => {
     expect(calls[0].observed).toBeUndefined();
   });
 
-  /** The odds-carrying rules quote them inside their own limit line, so the
-   * chance has to reach the template. Found by key rather than by position:
-   * building the chance is itself a translation, so it lands first. */
-  it("hands the chance to a rule that quotes it", () => {
+  /** NO PROBABILITIES ANYWHERE (user, 2026-08-03).
+   *
+   * The two report rules used to quote a percentage inside their own limit
+   * line. It measured the honest table price of the draws, which is not the
+   * question anyone was asking of a farmer who rerolls hundreds of times, so
+   * it was removed rather than left to be read as if it meant something. The
+   * claim is now the count alone.
+   */
+  it("quotes no probability, whatever odds the finding carries", () => {
     const { calls, t } = capture();
     describeLimit(t, longOdds);
 
-    const limit = calls.find((call) => call.key === "ui.legality.limit.summonPerfectCount");
-    expect(limit?.chance).toBe("ui.legality.chance-percent");
-    expect(calls.find((call) => call.key === "ui.legality.chance-percent")?.percent).toBe("0.000047");
-  });
-
-  /** Below a point a percentage is a row of zeroes rather than a quantity, and
-   * words carry it better. */
-  it("stops quoting a percentage once it has stopped meaning anything", () => {
-    const { calls, t } = capture();
-    describeLimit(t, { ...longOdds, odds: 1 / 96_281_828_704 });
-
-    expect(calls.some((call) => call.key === "ui.legality.chance-impossible")).toBe(true);
-    expect(calls.some((call) => call.key === "ui.legality.chance-percent")).toBe(false);
+    expect(calls.every((call) => !String(call.key).startsWith("ui.legality.chance"))).toBe(true);
+    expect(calls.some((call) => "chance" in call)).toBe(false);
   });
 
   it("falls back to the rule's own key rather than rendering nothing", () => {

--- a/src/legality.ts
+++ b/src/legality.ts
@@ -75,33 +75,6 @@ const limitKey = (finding: LegalityFinding): string => {
   return unnamed ? `${key}-unnamed` : key;
 };
 
-/** Below this, a percentage stops conveying anything — `0.0000000010%` is a
- * row of zeroes, not a quantity — so the odds are stated in words instead. */
-const BEYOND_CHANCE = 1e-9;
-
-/**
- * Odds as the percentage a reader can picture, or words when the number has
- * stopped meaning anything.
- *
- * "1 in 953" was the old form and it failed twice over: the denominator had no
- * unit, and a reader has to invert it to judge it. A percentage needs neither
- * step. Significant digits rather than fixed decimals, because these span nine
- * orders of magnitude and `0.00%` is not an answer.
- */
-const describeChance = (t: TFunction, odds: number | null): string => {
-  if (odds === null || odds === undefined || odds <= 0) return "";
-  if (odds < BEYOND_CHANCE) return t("ui.legality.chance-impossible");
-
-  const percent = odds * 100;
-  // `toPrecision` gives exponent form below 1e-6; expanded with `toFixed`,
-  // since "1.2e-5%" is worse than the row of zeroes it was avoiding.
-  const written = Number(percent.toPrecision(2))
-    .toFixed(Math.max(0, 1 - Math.floor(Math.log10(percent))))
-    .replace(/\.?0+$/, "");
-
-  return t("ui.legality.chance-percent", { percent: written });
-};
-
 /**
  * What the game allows, phrased to sit immediately after a gear line —
  * `max 20`, `doesn't roll on this summon`, `max +50`.
@@ -124,8 +97,12 @@ export const describeLimit = (
    * reading "+75%" leaves the reader to finish the comparison. */
   allowed?: string
 ): string =>
+  // No probability reaches the template. The two report rules used to quote
+  // one; it priced the draws honestly and the question dishonestly, since a
+  // farmer rerolls hundreds of times, so the claim is now the count alone
+  // (user, 2026-08-03). `finding.odds` survives on the wire and is simply not
+  // rendered anywhere.
   t(limitKey(finding), {
     observed: displayValue(finding.observed, slot),
     allowed: allowed ?? displayValue(finding.allowed, slot),
-    chance: describeChance(t, finding.odds),
   });

--- a/src/legalityStrings.test.ts
+++ b/src/legalityStrings.test.ts
@@ -41,6 +41,15 @@ const FIXTURES: Record<LegalityRule, LegalityFinding> = {
     allowed: { kind: "levels", value: [20, 15, 10] },
     odds: null,
   },
+  wrightstoneTrait: {
+    rule: "wrightstoneTrait",
+    subject: { kind: "wrightstone" },
+    // War Elemental, a SIGIL trait. `allowed` is None: the pool is 71 traits,
+    // so the claim is the trait itself rather than a list.
+    observed: { kind: "traitId", value: 0x4c588c27 },
+    allowed: { kind: "none" },
+    odds: null,
+  },
   sigilTraitLevel: {
     rule: "sigilTraitLevel",
     subject: { kind: "sigil", index: 7 },
@@ -165,7 +174,8 @@ describe("which rules speak", () => {
    * prose competing with the item rather than annotating it.
    *
    * Exempt are the rules whose claim IS the text rather than an annotation on
-   * something the line already shows. The two odds rules state a probability.
+   * something the line already shows. The two report rules state a count about
+   * a whole set, which no single gear line shows.
    * `summonBonusSource` names the summons that do grant the bonus, and has to:
    * two ids share every effect's display name, so its line reads "Healing Cap
    * Up" whether or not this summon may hold that one — there is nothing on it
@@ -221,24 +231,20 @@ describe("limit strings", () => {
     expect(describeLimit(t, FIXTURES.wrightstoneTraitLevel, 2)).toBe("max 10");
   });
 
-  /** Severity is gone, so the odds ARE the distinction between a report of
-   * long luck and proof the game could not have produced a build. A rule that
-   * carries them must say them, as a percentage rather than a "1 in N" the
-   * reader has to invert before it means anything. */
-  it("quote the odds on the rules that are reports rather than proof", () => {
-    expect(describeLimit(t, FIXTURES.overmasteryAllMaxed)).toBe("3 max Stun Power Up rolls — 0.038% chance");
-    expect(describeLimit(t, FIXTURES.summonPerfectCount)).toBe("4 perfect summon rolls — 0.0024% chance");
-  });
+  /** NO PROBABILITIES (user, 2026-08-03). The two report rules used to quote a
+   * percentage. It priced the table's draws honestly and the reader's question
+   * dishonestly — a farmer rerolls hundreds of times — so the claim is now the
+   * count alone, and no odds reach any string whatever the finding carries. */
+  it("state the report rules as a count, with no probability", () => {
+    expect(describeLimit(t, FIXTURES.overmasteryAllMaxed)).toBe("3 max Stun Power Up rolls");
+    expect(describeLimit(t, FIXTURES.summonPerfectCount)).toBe("4 perfect summon rolls");
 
-  /** Past a point a percentage is a row of zeroes rather than a quantity, and
-   * words carry it better. */
-  it("give up on a percentage once it stops meaning anything", () => {
     expect(
       describeLimit(t, {
         ...FIXTURES.summonPerfectCount,
         observed: { kind: "count", value: 3 },
         odds: 1 / 96_281_828_704,
       })
-    ).toBe("3 perfect summon rolls — completely impossible");
+    ).toBe("3 perfect summon rolls");
   });
 });

--- a/src/pages/logs/Index.flagged.test.tsx
+++ b/src/pages/logs/Index.flagged.test.tsx
@@ -164,6 +164,42 @@ describe("the quest list's flagged players", () => {
     expect(screen.getByRole("row", { name: /Manmoth/ })).toBeTruthy();
   });
 
+  /** A Repeat Quest chain draws its party once, on the band; the runs beneath
+   * it leave that column to it and start collapsed. So the band has to carry
+   * the verdicts of every run under it — read off the leader alone, a build
+   * flagged on the third run of a farming session would be marked nowhere at
+   * all, including for somebody who filtered the list down to flagged runs. */
+  it("marks a build flagged on a later run of a collapsed chain", () => {
+    const leader = { ...log(), id: 42, repeatGroup: null } as Log;
+    const laterRun = { ...log(), id: 43, time: 2, repeatGroup: 42 } as Log;
+    const searchResult = {
+      logs: [leader, laterRun],
+      page: 1,
+      pageCount: 1,
+      logCount: 2,
+      enemyIds: [],
+      questIds: [],
+      playerIds: [],
+      playerTypes: [],
+      // Only the later run was flagged, and it is the one the collapsed chain
+      // does not draw.
+      legality: { 43: [findingAgainstSlotOne()] } as Record<string, StoredLegalityFinding[]>,
+    };
+
+    useLogIndexStore.setState({ searchResult });
+    invoke.mockResolvedValue(searchResult);
+
+    const { container } = render(
+      <MantineProvider>
+        <MemoryRouter>
+          <IndexPage />
+        </MemoryRouter>
+      </MantineProvider>
+    );
+
+    expect(markedNames(container)).toEqual(["char:Pl1300 (Manmoth)"]);
+  });
+
   it("offers the flagged filter only while flagged builds are shown", () => {
     useLogIndexStore.setState({ filters: { ...useLogIndexStore.getState().filters, showAdvancedFilters: true } });
 

--- a/src/pages/logs/Index.tsx
+++ b/src/pages/logs/Index.tsx
@@ -134,6 +134,11 @@ export const IndexPage = () => {
             streamerMode: streamer_mode,
             t,
           })}
+          // The band draws the chain's party, so it has to carry the chain's
+          // verdicts too — the runs beneath it no longer draw names, and a
+          // flagged build in a collapsed chain would otherwise be invisible
+          // even to somebody who filtered the list down to it.
+          findings={show_flagged_builds ? mergeChainFindings(runs, searchResult.legality) : undefined}
         />
       );
 
@@ -335,6 +340,26 @@ function PartyNames({ members, findings }: { members: PartyMember[]; findings?: 
 const chainSpineStyle = (chainColor?: string): React.CSSProperties | undefined =>
   chainColor === undefined ? undefined : ({ "--logs-chain-color": chainColor } as React.CSSProperties);
 
+/** Every verdict recorded against a chain, as one set.
+ *
+ * A Repeat Quest chain is one party playing the same quest over, so a build
+ * flagged in any of its runs is flagged for the chain — and the band is the
+ * only row that draws the names, so it is the only place the mark can land.
+ * Identical findings collapse: repeated across a dozen runs they would print
+ * the same accusation a dozen times in one tooltip. */
+function mergeChainFindings(
+  runs: Log[],
+  legality: Record<string, StoredLegalityFinding[]> | undefined
+): StoredLegalityFinding[] {
+  const unique = new Map<string, StoredLegalityFinding>();
+  for (const run of runs) {
+    for (const stored of legality?.[run.id] ?? []) {
+      unique.set(JSON.stringify(stored), stored);
+    }
+  }
+  return [...unique.values()];
+}
+
 /** The row a Repeat Quest chain is drawn as: what the set of runs beneath it
  * amounts to, not one of the runs standing in for the rest.
  *
@@ -358,6 +383,7 @@ function ChainSummaryRow({
   questLabel,
   primaryTarget,
   members,
+  findings,
 }: {
   runs: Log[];
   /** Computed by the page, which needs the same figures to mark the run that
@@ -375,6 +401,10 @@ function ChainSummaryRow({
   questLabel: string;
   primaryTarget: string;
   members: PartyMember[];
+  /** Every verdict recorded against the chain's runs, or nothing when the user
+   * has asked not to see them. The runs beneath this row draw no names, so
+   * this is the only place a flagged build in a chain can be marked. */
+  findings?: StoredLegalityFinding[];
 }): JSX.Element {
   const { t } = useTranslation();
 
@@ -395,8 +425,10 @@ function ChainSummaryRow({
   // real run's time is the one figure that can sit in a column beside the
   // standalone runs without misleading. Carried in the same accent the run that
   // set it wears, so opening the chain shows the two are the same number.
+  // Only a real figure wears the accent: a chain nothing reported a time for
+  // draws a "-", and in bold cyan that dash reads as the record it is not.
   const bestCell = (bestMs: number | null) => (
-    <Text size="xs" className="logs-num logs-chain-best">
+    <Text size="xs" className={`logs-num${bestMs === null ? "" : " logs-chain-best"}`}>
       {bestMs === null ? "-" : millisecondsToElapsedFormat(bestMs)}
     </Text>
   );
@@ -434,7 +466,7 @@ function ChainSummaryRow({
       <Table.Td>{bestCell(summary.bestDurationMs)}</Table.Td>
       <Table.Td>{bestCell(summary.bestQuestElapsedMs)}</Table.Td>
       <Table.Td>
-        <PartyNames members={members} />
+        <PartyNames members={members} findings={findings} />
       </Table.Td>
       {/* The toggle sits in the actions column, among the View buttons of the
           runs it opens — it is the band's action, and the one control on this

--- a/src/pages/logs/Index.tsx
+++ b/src/pages/logs/Index.tsx
@@ -3,7 +3,6 @@ import { FilterState } from "@/stores/useLogIndexStore";
 import { useMeterSettingsStore } from "@/stores/useMeterSettingsStore";
 import { Log, LogSortType, SortDirection, StoredLegalityFinding } from "@/types";
 import {
-  PLAYER_COLORS,
   epochToLocalTime,
   hasQuestElapsedTime,
   millisecondsToElapsedFormat,
@@ -34,7 +33,14 @@ import { Link } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
 import "./logsTable.css";
 import { PartyMember, partyMembers } from "./partyMembers";
-import { chainKey, chainLatestTime, groupRepeatChains, summarizeChain } from "./repeatChains";
+import {
+  ChainSummary,
+  chainColors,
+  chainKey,
+  chainLatestTime,
+  groupRepeatChains,
+  summarizeChain,
+} from "./repeatChains";
 import useIndex from "./useIndex";
 
 export const IndexPage = () => {
@@ -72,62 +78,66 @@ export const IndexPage = () => {
 
   const chainGroups = useMemo(() => groupRepeatChains(searchResult.logs), [searchResult.logs]);
 
-  // A colour per chain, cycled through the party palette exactly as player rows
-  // are — two chains of the same quest, back to back, are otherwise told apart
-  // only by where one block of identical rows stops and the next begins.
-  //
-  // Counted over CHAINS, not over groups: advancing the colour on every
-  // unchained log between them would make the sequence look arbitrary and let
-  // neighbouring chains land on the same hue.
-  const chainColors = useMemo(() => {
-    const colors = new Map<number, string>();
-    let position = 0;
-    for (const group of chainGroups) {
-      if (group.rest.length === 0) continue;
-      colors.set(chainKey(group.leader), PLAYER_COLORS[position % PLAYER_COLORS.length]);
-      position += 1;
-    }
-    return colors;
+  // Everything about a chain that does not depend on what is selected or open,
+  // derived once per page. `runs` in particular: rebuilt inline it was a fresh
+  // array on every render, which is what made the summary memos downstream miss
+  // every time and recompute anyway.
+  const chains = useMemo(() => {
+    const colors = chainColors(chainGroups);
+    return chainGroups.map((group) => {
+      const runs = [group.leader, ...group.rest];
+      const chained = group.rest.length > 0;
+
+      return {
+        key: chainKey(group.leader),
+        leader: group.leader,
+        runs,
+        chained,
+        color: colors.get(chainKey(group.leader)),
+        // Only within a chain: a lone log is trivially its own best, and
+        // marking every unchained row would make the accent mean nothing.
+        summary: chained ? summarizeChain(runs) : null,
+        latest: chained ? chainLatestTime(runs) : null,
+      };
+    });
   }, [chainGroups]);
 
-  const rows = chainGroups.flatMap((group) => {
-    const key = chainKey(group.leader);
-    const chained = group.rest.length > 0;
-    const collapsed = !expandedChains.includes(key);
-    const runs = [group.leader, ...group.rest];
-    const visible = !chained || !collapsed ? runs : [];
-    // Only within a chain: a lone log is trivially its own best, and colouring
-    // every unchained row would make the mark mean nothing.
-    const best = chained ? summarizeChain(runs) : null;
+  // Membership answered in one step per row rather than a scan of the selection
+  // per row — with "select all on page" ticked, every chain was rescanning the
+  // whole page for each of its runs.
+  const selectedIds = useMemo(() => new Set(selectedLogIds), [selectedLogIds]);
+
+  const rows = chains.flatMap(({ key, leader, runs, chained, color, summary, latest }) => {
+    const expanded = expandedChains.includes(key);
+    const visible = chained && !expanded ? [] : runs;
 
     // A summary standing for the whole chain, rather than promoting one run to
     // speak for the others: the runs below it are its detail, and the figures
     // here are about the set.
-    const chainColor = chainColors.get(key);
-
-    const summaryRow = chained ? (
-      <ChainSummaryRow
-        key={`chain-${key}`}
-        runs={runs}
-        chainColor={chainColor}
-        collapsed={collapsed}
-        onToggle={() => toggleChain(key)}
-        selectedLogIds={selectedLogIds}
-        setSelectedLogIds={setSelectedLogIds}
-        questLabel={translateQuestId(group.leader.questId)}
-        primaryTarget={translateEnemyType(group.leader.primaryTarget)}
-        members={partyMembers(group.leader, {
-          showDisplayNames: show_display_names,
-          streamerMode: streamer_mode,
-          t,
-        })}
-      />
-    ) : null;
+    const summaryRow =
+      summary === null ? null : (
+        <ChainSummaryRow
+          key={`chain-${key}`}
+          runs={runs}
+          summary={summary}
+          latest={latest}
+          chainColor={color}
+          expanded={expanded}
+          onToggle={() => toggleChain(key)}
+          selectedIds={selectedIds}
+          selectedLogIds={selectedLogIds}
+          setSelectedLogIds={setSelectedLogIds}
+          questLabel={translateQuestId(leader.questId)}
+          primaryTarget={translateEnemyType(leader.primaryTarget)}
+          members={partyMembers(leader, {
+            showDisplayNames: show_display_names,
+            streamerMode: streamer_mode,
+            t,
+          })}
+        />
+      );
 
     const runRows = visible.map((log) => {
-      const primaryTarget = translateEnemyType(log.primaryTarget);
-      const members = partyMembers(log, { showDisplayNames: show_display_names, streamerMode: streamer_mode, t });
-
       const resetSelectedTargets = () => {
         setSelectedTargetSpans([]);
       };
@@ -138,22 +148,27 @@ export const IndexPage = () => {
           log={log}
           selectedLogIds={selectedLogIds}
           setSelectedLogIds={setSelectedLogIds}
-          primaryTarget={primaryTarget}
-          members={members}
+          // A run inside a chain leaves these to the band above it, so they are
+          // resolved only for the rows that draw them — `partyMembers` alone is
+          // four i18next lookups a chained row would throw away.
+          primaryTarget={chained ? "" : translateEnemyType(log.primaryTarget)}
+          members={
+            chained ? [] : partyMembers(log, { showDisplayNames: show_display_names, streamerMode: streamer_mode, t })
+          }
           // Only when the user has asked to see verdicts at all. Withheld here
           // rather than at the mark, so the row cannot colour what it was never
           // given.
           findings={show_flagged_builds ? searchResult.legality?.[log.id] : undefined}
           resetSelectedTargets={resetSelectedTargets}
           chained={chained}
-          chainColor={chainColor}
-          bestDuration={best?.bestDurationId === log.id}
-          bestQuestElapsed={best?.bestQuestElapsedId === log.id}
+          chainColor={color}
+          bestDuration={summary?.bestDurationId === log.id}
+          bestQuestElapsed={summary?.bestQuestElapsedId === log.id}
         />
       );
     });
 
-    return summaryRow ? [summaryRow, ...runRows] : runRows;
+    return [summaryRow, ...runRows];
   });
 
   return (
@@ -252,7 +267,6 @@ export const IndexPage = () => {
             </Table.Thead>
             <Table.Tbody>{rows}</Table.Tbody>
           </Table>
-          <Divider my="sm" />
         </Box>
       )}
     </Box>
@@ -333,9 +347,12 @@ const chainSpineStyle = (chainColor?: string): React.CSSProperties | undefined =
  */
 function ChainSummaryRow({
   runs,
+  summary,
+  latest,
   chainColor,
-  collapsed,
+  expanded,
   onToggle,
+  selectedIds,
   selectedLogIds,
   setSelectedLogIds,
   questLabel,
@@ -343,10 +360,16 @@ function ChainSummaryRow({
   members,
 }: {
   runs: Log[];
+  /** Computed by the page, which needs the same figures to mark the run that
+   * set each best — one derivation, so the band and the accent cannot disagree
+   * about which run that is. */
+  summary: ChainSummary;
+  latest: number | null;
   /** This chain's colour from the party palette, drawn down its spine. */
   chainColor?: string;
-  collapsed: boolean;
+  expanded: boolean;
   onToggle: () => void;
+  selectedIds: Set<number>;
   selectedLogIds: number[];
   setSelectedLogIds: (ids: number[]) => void;
   questLabel: string;
@@ -354,11 +377,9 @@ function ChainSummaryRow({
   members: PartyMember[];
 }): JSX.Element {
   const { t } = useTranslation();
-  const summary = useMemo(() => summarizeChain(runs), [runs]);
-  const latest = useMemo(() => chainLatestTime(runs), [runs]);
 
   const ids = runs.map((run) => run.id);
-  const selected = ids.filter((id) => selectedLogIds.includes(id)).length;
+  const selected = ids.filter((id) => selectedIds.has(id)).length;
   const allSelected = selected === ids.length;
 
   // One tick selects the whole session — a chain is usually kept or deleted as
@@ -431,10 +452,10 @@ function ChainSummaryRow({
               onToggle();
             }}
             aria-label={t("ui.logs.repeat-chain-toggle", { count: runs.length })}
-            aria-expanded={!collapsed}
+            aria-expanded={expanded}
             className="logs-chain-toggle"
           >
-            {collapsed ? <CaretLeft size={16} weight="bold" /> : <CaretDown size={16} weight="bold" />}
+            {expanded ? <CaretDown size={16} weight="bold" /> : <CaretLeft size={16} weight="bold" />}
           </UnstyledButton>
         </Group>
       </Table.Td>
@@ -479,11 +500,7 @@ function LogEntry({
   const { t } = useTranslation();
 
   return (
-    <Table.Tr
-      key={log.id}
-      className={chained ? "logs-chain-run" : undefined}
-      style={chained ? chainSpineStyle(chainColor) : undefined}
-    >
+    <Table.Tr key={log.id} className={chained ? "logs-chain-run" : undefined} style={chainSpineStyle(chainColor)}>
       <Table.Td>
         <Checkbox
           aria-label="Select row"

--- a/src/pages/logs/Index.tsx
+++ b/src/pages/logs/Index.tsx
@@ -3,6 +3,7 @@ import { FilterState } from "@/stores/useLogIndexStore";
 import { useMeterSettingsStore } from "@/stores/useMeterSettingsStore";
 import { Log, LogSortType, SortDirection, StoredLegalityFinding } from "@/types";
 import {
+  PLAYER_COLORS,
   epochToLocalTime,
   hasQuestElapsedTime,
   millisecondsToElapsedFormat,
@@ -26,13 +27,14 @@ import {
   Tooltip,
   UnstyledButton,
 } from "@mantine/core";
-import { CaretDown, CaretRight, WarningCircle } from "@phosphor-icons/react";
+import { CaretDown, CaretLeft, WarningCircle } from "@phosphor-icons/react";
 import { Fragment, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
+import "./logsTable.css";
 import { PartyMember, partyMembers } from "./partyMembers";
-import { chainKey, groupRepeatChains } from "./repeatChains";
+import { chainKey, chainLatestTime, groupRepeatChains, summarizeChain } from "./repeatChains";
 import useIndex from "./useIndex";
 
 export const IndexPage = () => {
@@ -59,20 +61,70 @@ export const IndexPage = () => {
     }))
   );
 
-  // Repeat Quest chains collapse under their first row in display order;
-  // expansion is per chain, keyed by the chain parent's id.
+  // Repeat Quest chains start closed: a farming session is one entry in the
+  // list until the user asks for its runs, and a page of open chains buries the
+  // rest of the history under rows that all say the same thing. State tracks
+  // what has been EXPANDED, so the default (nothing here) is collapsed and a
+  // new page starts closed.
   const [expandedChains, setExpandedChains] = useState<number[]>([]);
   const toggleChain = (key: number) =>
     setExpandedChains((old) => (old.includes(key) ? old.filter((k) => k !== key) : [...old, key]));
 
   const chainGroups = useMemo(() => groupRepeatChains(searchResult.logs), [searchResult.logs]);
 
+  // A colour per chain, cycled through the party palette exactly as player rows
+  // are — two chains of the same quest, back to back, are otherwise told apart
+  // only by where one block of identical rows stops and the next begins.
+  //
+  // Counted over CHAINS, not over groups: advancing the colour on every
+  // unchained log between them would make the sequence look arbitrary and let
+  // neighbouring chains land on the same hue.
+  const chainColors = useMemo(() => {
+    const colors = new Map<number, string>();
+    let position = 0;
+    for (const group of chainGroups) {
+      if (group.rest.length === 0) continue;
+      colors.set(chainKey(group.leader), PLAYER_COLORS[position % PLAYER_COLORS.length]);
+      position += 1;
+    }
+    return colors;
+  }, [chainGroups]);
+
   const rows = chainGroups.flatMap((group) => {
     const key = chainKey(group.leader);
-    const expanded = expandedChains.includes(key);
-    const visible = expanded ? [group.leader, ...group.rest] : [group.leader];
+    const chained = group.rest.length > 0;
+    const collapsed = !expandedChains.includes(key);
+    const runs = [group.leader, ...group.rest];
+    const visible = !chained || !collapsed ? runs : [];
+    // Only within a chain: a lone log is trivially its own best, and colouring
+    // every unchained row would make the mark mean nothing.
+    const best = chained ? summarizeChain(runs) : null;
 
-    return visible.map((log, position) => {
+    // A summary standing for the whole chain, rather than promoting one run to
+    // speak for the others: the runs below it are its detail, and the figures
+    // here are about the set.
+    const chainColor = chainColors.get(key);
+
+    const summaryRow = chained ? (
+      <ChainSummaryRow
+        key={`chain-${key}`}
+        runs={runs}
+        chainColor={chainColor}
+        collapsed={collapsed}
+        onToggle={() => toggleChain(key)}
+        selectedLogIds={selectedLogIds}
+        setSelectedLogIds={setSelectedLogIds}
+        questLabel={translateQuestId(group.leader.questId)}
+        primaryTarget={translateEnemyType(group.leader.primaryTarget)}
+        members={partyMembers(group.leader, {
+          showDisplayNames: show_display_names,
+          streamerMode: streamer_mode,
+          t,
+        })}
+      />
+    ) : null;
+
+    const runRows = visible.map((log) => {
       const primaryTarget = translateEnemyType(log.primaryTarget);
       const members = partyMembers(log, { showDisplayNames: show_display_names, streamerMode: streamer_mode, t });
 
@@ -93,15 +145,15 @@ export const IndexPage = () => {
           // given.
           findings={show_flagged_builds ? searchResult.legality?.[log.id] : undefined}
           resetSelectedTargets={resetSelectedTargets}
-          chain={
-            position === 0 && group.rest.length > 0
-              ? { count: group.rest.length + 1, expanded, onToggle: () => toggleChain(key) }
-              : undefined
-          }
-          chained={position > 0}
+          chained={chained}
+          chainColor={chainColor}
+          bestDuration={best?.bestDurationId === log.id}
+          bestQuestElapsed={best?.bestQuestElapsedId === log.id}
         />
       );
     });
+
+    return summaryRow ? [summaryRow, ...runRows] : runRows;
   });
 
   return (
@@ -121,7 +173,10 @@ export const IndexPage = () => {
           )}
         </Group>
       </Box>
-      <Box>
+      {/* The gap belongs to the filters, not to the pager below them: this Box
+          still renders when the filters are hidden, so spacing the pager
+          unconditionally would leave a hole under a row that is not there. */}
+      <Box pb={filters.showAdvancedFilters ? "xs" : undefined}>
         <Group>
           {filters.showAdvancedFilters && (
             <SelectablePlayer playerIds={searchResult.playerIds} setFilters={setFilters} filters={filters} />
@@ -140,7 +195,13 @@ export const IndexPage = () => {
       {searchResult.logs.length === 0 && <BlankTable />}
       {searchResult.logs.length > 0 && (
         <Box>
-          <Table striped highlightOnHover>
+          <Group justify="space-between">
+            <Pagination total={searchResult.pageCount} value={currentPage} onChange={handleSetPage} />
+            <Text size="sm" c="dimmed">
+              {t("ui.logs.saved-count", { count: searchResult.logCount })}
+            </Text>
+          </Group>
+          <Table striped highlightOnHover className="logs-table">
             <Table.Thead>
               <Table.Tr>
                 <Table.Th>
@@ -192,12 +253,6 @@ export const IndexPage = () => {
             <Table.Tbody>{rows}</Table.Tbody>
           </Table>
           <Divider my="sm" />
-          <Group justify="space-between">
-            <Pagination total={searchResult.pageCount} value={currentPage} onChange={handleSetPage} />
-            <Text size="sm" c="dimmed">
-              {t("ui.logs.saved-count", { count: searchResult.logCount })}
-            </Text>
-          </Group>
         </Box>
       )}
     </Box>
@@ -259,6 +314,134 @@ function PartyNames({ members, findings }: { members: PartyMember[]; findings?: 
   );
 }
 
+/** Hands a chain's colour to the stylesheet, which draws the spine and tints
+ * the band from it. A custom property rather than an inline `boxShadow` so the
+ * shape of the spine stays in CSS with the rest of the block's styling and only
+ * the hue crosses over. */
+const chainSpineStyle = (chainColor?: string): React.CSSProperties | undefined =>
+  chainColor === undefined ? undefined : ({ "--logs-chain-color": chainColor } as React.CSSProperties);
+
+/** The row a Repeat Quest chain is drawn as: what the set of runs beneath it
+ * amounts to, not one of the runs standing in for the rest.
+ *
+ * It fills the same columns as a run so the table still reads down a column,
+ * but only where a figure about the SET means something. The times become the
+ * chain's best — the run it peaked at, which is also the run the list places
+ * the block by — while the cleared mark and the View button stay empty: a
+ * chain has no single outcome and no one run to open, and answering those
+ * would be inventing one.
+ */
+function ChainSummaryRow({
+  runs,
+  chainColor,
+  collapsed,
+  onToggle,
+  selectedLogIds,
+  setSelectedLogIds,
+  questLabel,
+  primaryTarget,
+  members,
+}: {
+  runs: Log[];
+  /** This chain's colour from the party palette, drawn down its spine. */
+  chainColor?: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  selectedLogIds: number[];
+  setSelectedLogIds: (ids: number[]) => void;
+  questLabel: string;
+  primaryTarget: string;
+  members: PartyMember[];
+}): JSX.Element {
+  const { t } = useTranslation();
+  const summary = useMemo(() => summarizeChain(runs), [runs]);
+  const latest = useMemo(() => chainLatestTime(runs), [runs]);
+
+  const ids = runs.map((run) => run.id);
+  const selected = ids.filter((id) => selectedLogIds.includes(id)).length;
+  const allSelected = selected === ids.length;
+
+  // One tick selects the whole session — a chain is usually kept or deleted as
+  // a unit, and ticking five rows by hand to drop one farming run is busywork.
+  const toggleSelection = () =>
+    setSelectedLogIds(
+      allSelected ? selectedLogIds.filter((id) => !ids.includes(id)) : [...new Set([...selectedLogIds, ...ids])]
+    );
+
+  // The chain's best, bare and in the column it belongs to — the band's own
+  // styling says the figure is about the set, so a label repeating it on every
+  // chain earned nothing. Closed, this is the only time the block shows, and a
+  // real run's time is the one figure that can sit in a column beside the
+  // standalone runs without misleading. Carried in the same accent the run that
+  // set it wears, so opening the chain shows the two are the same number.
+  const bestCell = (bestMs: number | null) => (
+    <Text size="xs" className="logs-num logs-chain-best">
+      {bestMs === null ? "-" : millisecondsToElapsedFormat(bestMs)}
+    </Text>
+  );
+
+  return (
+    // The whole band toggles: it is a heading for the rows under it, and a
+    // 26px caret at the far end of a wide row is a small thing to ask for. The
+    // caret stays as the labelled, keyboard-reachable control.
+    <Table.Tr className="logs-chain-summary" style={chainSpineStyle(chainColor)} onClick={onToggle}>
+      {/* Selecting a chain is not opening it, so the checkbox keeps its click
+          to itself — without this, ticking it would also fold the runs away. */}
+      <Table.Td onClick={(event: React.MouseEvent) => event.stopPropagation()}>
+        <Checkbox
+          aria-label={t("ui.logs.repeat-chain-select", { count: runs.length })}
+          checked={allSelected}
+          indeterminate={selected > 0 && !allSelected}
+          onChange={toggleSelection}
+        />
+      </Table.Td>
+      {/* The chain's most recent run, which is what the list is sorted by and
+          what dates the chain wherever it sits. Not a range: showing one end of
+          one read as a claim about the whole block. */}
+      <Table.Td>
+        <Text size="xs" className="logs-num">
+          {latest === null ? "" : epochToLocalTime(latest)}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="xs">{questLabel}</Text>
+      </Table.Td>
+      <Table.Td></Table.Td>
+      <Table.Td>
+        <Text size="xs">{primaryTarget}</Text>
+      </Table.Td>
+      <Table.Td>{bestCell(summary.bestDurationMs)}</Table.Td>
+      <Table.Td>{bestCell(summary.bestQuestElapsedMs)}</Table.Td>
+      <Table.Td>
+        <PartyNames members={members} />
+      </Table.Td>
+      {/* The toggle sits in the actions column, among the View buttons of the
+          runs it opens — it is the band's action, and the one control on this
+          row that does something to the rows below. Centred rather than pushed
+          to the edge: alone in its column it needs to read as a control, not as
+          a stray glyph. Collapsed points LEFT, back toward the rows it folded
+          away; on a right-hand disclosure a right-pointing caret aims at
+          nothing. */}
+      <Table.Td>
+        <Group gap={6} wrap="nowrap" justify="center">
+          <UnstyledButton
+            // Stopped, or the row's own handler would toggle it straight back.
+            onClick={(event: React.MouseEvent) => {
+              event.stopPropagation();
+              onToggle();
+            }}
+            aria-label={t("ui.logs.repeat-chain-toggle", { count: runs.length })}
+            aria-expanded={!collapsed}
+            className="logs-chain-toggle"
+          >
+            {collapsed ? <CaretLeft size={16} weight="bold" /> : <CaretDown size={16} weight="bold" />}
+          </UnstyledButton>
+        </Group>
+      </Table.Td>
+    </Table.Tr>
+  );
+}
+
 function LogEntry({
   log,
   selectedLogIds,
@@ -267,8 +450,10 @@ function LogEntry({
   members,
   findings,
   resetSelectedTargets,
-  chain,
   chained,
+  chainColor,
+  bestDuration,
+  bestQuestElapsed,
 }: {
   log: Log;
   selectedLogIds: number[];
@@ -279,17 +464,26 @@ function LogEntry({
    * them — which reads the same as a log nobody was flagged in. */
   findings?: StoredLegalityFinding[];
   resetSelectedTargets: () => void;
-  /** Present on the visible row of a collapsed/expanded Repeat Quest chain:
-   * how many runs it stands for, and the expand/collapse toggle. */
-  chain?: { count: number; expanded: boolean; onToggle: () => void };
-  /** True on the later rows of an expanded chain — indented under the row
-   * carrying the toggle. */
+  /** This chain's colour from the party palette, drawn down its spine. */
+  chainColor?: string;
+  /** True for a run inside a Repeat Quest chain. The band above it already
+   * states everything that is constant across the chain — quest, enemy, party
+   * — so this row leaves those cells to it and fills only what varies. */
   chained?: boolean;
+  /** Marks this run as the chain's fastest by wall-clock and by in-game time.
+   * The two can be different runs: a fight can end quickly and still sit in a
+   * long post-clear wrap-up. */
+  bestDuration?: boolean;
+  bestQuestElapsed?: boolean;
 }): JSX.Element {
   const { t } = useTranslation();
 
   return (
-    <Table.Tr key={log.id}>
+    <Table.Tr
+      key={log.id}
+      className={chained ? "logs-chain-run" : undefined}
+      style={chained ? chainSpineStyle(chainColor) : undefined}
+    >
       <Table.Td>
         <Checkbox
           aria-label="Select row"
@@ -301,47 +495,37 @@ function LogEntry({
           }
         />
       </Table.Td>
+      {/* The full stamp, chained or not: the band above states no date, so
+          these rows are the only thing that dates the chain. The rail on this
+          cell carries the nesting — indenting the text instead stepped one
+          column out of its own header's track. */}
       <Table.Td>
-        <Group gap={6} wrap="nowrap" pl={chained ? "lg" : undefined}>
-          {chain && (
-            <Tooltip label={t("ui.logs.repeat-chain-tooltip", { count: chain.count })} multiline w={280}>
-              <UnstyledButton
-                onClick={chain.onToggle}
-                aria-label={t("ui.logs.repeat-chain-tooltip", { count: chain.count })}
-              >
-                <Group gap={2} wrap="nowrap">
-                  {chain.expanded ? <CaretDown size={12} /> : <CaretRight size={12} />}
-                  <Text size="xs" fw={700}>
-                    {t("ui.logs.repeat-chain-count", { count: chain.count })}
-                  </Text>
-                </Group>
-              </UnstyledButton>
-            </Tooltip>
-          )}
-          <Text size="xs">{epochToLocalTime(log.time)}</Text>
-        </Group>
+        <Text size="xs" className="logs-num">
+          {epochToLocalTime(log.time)}
+        </Text>
       </Table.Td>
+      {/* Quest, enemy and party are the band's to state. Blanking only some of
+          what a chain holds constant left holes in different columns on
+          different rows, which read as broken markup rather than as ditto. */}
+      <Table.Td>{!chained && <Text size="xs">{translateQuestId(log.questId)}</Text>}</Table.Td>
+      <Table.Td>{log.questId && log.questCompleted !== null && (log.questCompleted ? "✓" : "✕")}</Table.Td>
+      <Table.Td>{!chained && <Text size="xs">{primaryTarget}</Text>}</Table.Td>
+      {/* Weight as well as colour, so the chain's fastest still stands out for
+          a reader who cannot separate the accent from the ✓ two cells over. */}
       <Table.Td>
-        <Text size="xs">{translateQuestId(log.questId)}</Text>
-      </Table.Td>
-      <Table.Td>{log.questId && log.questCompleted !== null && (log.questCompleted ? "✓" : "X")}</Table.Td>
-      <Table.Td>
-        <Text size="xs">{primaryTarget}</Text>
-      </Table.Td>
-      <Table.Td>
-        <Text size="xs">{millisecondsToElapsedFormat(log.duration)}</Text>
+        <Text size="xs" className={`logs-num${bestDuration ? " logs-chain-best" : ""}`}>
+          {millisecondsToElapsedFormat(log.duration)}
+        </Text>
       </Table.Td>
       {/* In-game time. A dash on logs recorded before the quest timer was read
           correctly, and on fights the game never reported one for — those
           stored a constant 1s, which would otherwise read as a real 00:01. */}
       <Table.Td>
-        <Text size="xs">
+        <Text size="xs" className={`logs-num${bestQuestElapsed ? " logs-chain-best" : ""}`}>
           {hasQuestElapsedTime(log.questElapsedTime) ? millisecondsToElapsedFormat(log.questElapsedTime * 1000) : "-"}
         </Text>
       </Table.Td>
-      <Table.Td>
-        <PartyNames members={members} findings={findings} />
-      </Table.Td>
+      <Table.Td>{!chained && <PartyNames members={members} findings={findings} />}</Table.Td>
       <Table.Td>
         <Group gap={6} wrap="nowrap" justify="flex-end">
           {log.imported && (

--- a/src/pages/logs/View.test.tsx
+++ b/src/pages/logs/View.test.tsx
@@ -1,6 +1,6 @@
 import { MantineProvider } from "@mantine/core";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // `t` returns the key, so assertions read against keys rather than English.
 vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
@@ -24,6 +24,48 @@ const renderIt = () =>
 describe("ViewPage", () => {
   beforeEach(() => {
     useMeterSettingsStore.setState({ logs_view_mode: "analysis" });
+  });
+
+  /**
+   * THE SHIPPING GATE. The Analysis view is unfinished, so a release build must
+   * not offer it at all.
+   *
+   * Hiding the switch is not enough on its own: `logs_view_mode` defaults to
+   * "analysis" and is PERSISTED, so anyone who has already opened a quest on a
+   * dev build carries that setting into the release and would be stranded on
+   * the half-built view with no control left to escape it. The release ignores
+   * the setting outright rather than defaulting it.
+   *
+   * Vitest runs with `DEV` true, so every other test in this file is the
+   * dev-mode behaviour and this block is the only one that has to say so.
+   */
+  describe("in a release build", () => {
+    beforeEach(() => {
+      vi.stubEnv("DEV", false);
+    });
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("shows the classic view even when the stored setting says analysis", () => {
+      useMeterSettingsStore.setState({ logs_view_mode: "analysis" });
+      renderIt();
+
+      expect(screen.getByText("classic-body")).toBeTruthy();
+      expect(screen.queryByText("analysis-body")).toBeNull();
+    });
+
+    it("offers no way to switch views", () => {
+      renderIt();
+      expect(screen.queryByRole("radio")).toBeNull();
+    });
+
+    /** The setting is left ALONE rather than rewritten to "classic": a dev who
+     * flips back to a dev build should find their own choice still there. */
+    it("does not overwrite the stored setting", () => {
+      renderIt();
+      expect(useMeterSettingsStore.getState().logs_view_mode).toBe("analysis");
+    });
   });
 
   it("renders the analysis view by default", () => {

--- a/src/pages/logs/View.tsx
+++ b/src/pages/logs/View.tsx
@@ -9,11 +9,31 @@ import { ClassicView } from "./view/ClassicView";
 /** Chooses between the redesigned Analysis frame and the original four-tab
  * Classic view, and holds nothing else — the two bodies own their own data
  * fetching, because their filter shapes differ (see the plan's "classic view
- * stays" rules). */
+ * stays" rules).
+ *
+ * THE ANALYSIS VIEW IS DEV-ONLY for now: it is unfinished, so a release build
+ * shows Classic and offers no switch. Everything below the guard is what the
+ * page will be again once Analysis ships — deleting the guard is the whole
+ * change.
+ *
+ * The guard IGNORES `logs_view_mode` rather than defaulting it. The setting is
+ * persisted and already defaults to "analysis", so anyone who has opened a
+ * quest on a dev build carries that value into the release; merely hiding the
+ * switch would strand them on the half-built view with no control left to
+ * escape it. The stored value is left untouched, so a dev build still finds the
+ * choice its owner made. */
 export const ViewPage = () => {
   const { t } = useTranslation();
   const mode = useMeterSettingsStore((state) => state.logs_view_mode);
   const setSettings = useMeterSettingsStore((state) => state.set);
+
+  if (!import.meta.env.DEV) {
+    return (
+      <Box>
+        <ClassicView />
+      </Box>
+    );
+  }
 
   return (
     <Box>

--- a/src/pages/logs/logsTable.css
+++ b/src/pages/logs/logsTable.css
@@ -15,6 +15,15 @@
  * stylesheet order.
  */
 
+.logs-table {
+  /* The analysis view's accent (`--an-accent` in analysis.css, and
+     PLAYER_COLORS[3]), declared once here rather than written as a literal at
+     each use. That token is scoped to `.analysis-tokens`, which does not wrap
+     this table, so it cannot simply be referenced — but a single declaration
+     keeps the two places this table needs it in step with each other. */
+  --logs-accent: #00b8d9;
+}
+
 /* The whole chain reads as one object lifted off the page: the band brightest,
    its runs a step above the page behind them, everything outside untouched.
    Three tones rather than a rule alone — a single hairline is easy to miss in a
@@ -86,7 +95,7 @@
 }
 
 .logs-chain-toggle:focus-visible {
-  outline: 2px solid #00b8d9;
+  outline: 2px solid var(--logs-accent);
   outline-offset: 1px;
 }
 
@@ -100,6 +109,6 @@
    this app means "cleared" (see the ✓ two cells away, and QuestSummary's
    teal.4), so a green record time reads as an outcome rather than a best. */
 .logs-chain-best {
-  color: #00b8d9;
+  color: var(--logs-accent);
   font-weight: 700;
 }

--- a/src/pages/logs/logsTable.css
+++ b/src/pages/logs/logsTable.css
@@ -1,0 +1,105 @@
+/* Repeat Quest chain blocks in the quest list.
+ *
+ * These rows set their own background rather than letting Mantine's `striped`
+ * decide it. That stripe is POSITIONAL —
+ * `:where(tr):where([data-striped='odd']:nth-of-type(odd))` counts `tr`
+ * siblings inside the tbody — so a chain's summary row was banded or not
+ * according to how many rows happened to precede it on the page, and every
+ * chain flipped the parity of every row after it. The one row whose whole job
+ * is to look unlike the others had its appearance decided by an accident of
+ * index.
+ *
+ * Selectors are deliberately two classes deep: Mantine's own rules are wrapped
+ * in `:where()` and so carry zero specificity, but the striping is applied to
+ * the same element, and matching it plainly would leave the winner up to
+ * stylesheet order.
+ */
+
+/* The whole chain reads as one object lifted off the page: the band brightest,
+   its runs a step above the page behind them, everything outside untouched.
+   Three tones rather than a rule alone — a single hairline is easy to miss in a
+   striped list, and the runs have to look like they belong to the band even
+   when the eye is halfway down the block. */
+/* A wash of the chain's own colour over the band, kept to 14% so the row stays
+   a surface the text sits on rather than becoming a coloured bar. `transparent`
+   in the fallback leaves the plain dark band when no colour was handed down. */
+.logs-table tbody tr.logs-chain-summary {
+  cursor: pointer;
+  background-color: var(--mantine-color-dark-6);
+  background-image: linear-gradient(
+    to right,
+    color-mix(in srgb, var(--logs-chain-color, transparent) 14%, transparent),
+    transparent 60%
+  );
+}
+
+/* The whole band opens and closes the chain, so it answers to the pointer —
+   a step lighter, which is the promise that clicking does something. */
+.logs-table tbody tr.logs-chain-summary:hover {
+  background-color: var(--mantine-color-dark-5);
+}
+
+/* Between the page (#252525) and the band, so the block is visibly one mass. */
+.logs-table tbody tr.logs-chain-run {
+  background-color: #2a2a2a;
+}
+
+.logs-table tbody tr.logs-chain-run:hover {
+  background-color: var(--mantine-color-dark-5);
+}
+
+/* The spine: one continuous edge down the band and every run under it, marking
+   where the block starts and ends without boxing it in. An inset shadow rather
+   than padding on a column — rows touch, so this draws an unbroken line, and
+   every column stays in the track its own header sits in. Indenting the date
+   cell instead read as a misaligned column, not a hierarchy.
+
+   The hue is the chain's own, cycled through the party palette by `Index.tsx`,
+   so two chains running back to back are told apart by colour rather than by
+   spotting where one block of near-identical rows ends. Falls back to a neutral
+   when no colour was handed down. */
+.logs-table tbody tr.logs-chain-summary > td:first-of-type,
+.logs-table tbody tr.logs-chain-run > td:first-of-type {
+  box-shadow: inset 3px 0 0 var(--logs-chain-color, var(--mantine-color-dark-2));
+}
+
+/* The band's disclosure control. Sized to a real hit target and given its own
+   hover and focus states: alone in the actions column it has to read as a
+   button rather than as a glyph that happens to be there.
+
+   30px is the height of the `xs` View buttons it shares a column with, so the
+   band and the runs come out the same height — a shorter control let the cell
+   padding decide the band's height, and the chain's own heading ended up the
+   one row in the block that didn't line up. */
+.logs-chain-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 4px;
+  color: var(--mantine-color-dark-0);
+}
+
+.logs-chain-toggle:hover {
+  background-color: var(--mantine-color-dark-4);
+}
+
+.logs-chain-toggle:focus-visible {
+  outline: 2px solid #00b8d9;
+  outline-offset: 1px;
+}
+
+/* Times line up digit-for-digit, which is the whole point of putting a chain's
+   runs under one another. */
+.logs-table .logs-num {
+  font-variant-numeric: tabular-nums;
+}
+
+/* The fastest run in a chain. The analysis view's accent, NOT a green: green in
+   this app means "cleared" (see the ✓ two cells away, and QuestSummary's
+   teal.4), so a green record time reads as an outcome rather than a best. */
+.logs-chain-best {
+  color: #00b8d9;
+  font-weight: 700;
+}

--- a/src/pages/logs/repeatChains.test.ts
+++ b/src/pages/logs/repeatChains.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { chainKey, chainLatestTime, groupRepeatChains, summarizeChain } from "./repeatChains";
+import { PLAYER_COLORS } from "@/utils";
+
+import { chainColors, chainKey, chainLatestTime, groupRepeatChains, summarizeChain } from "./repeatChains";
 
 type Row = { id: number; repeatGroup?: number | null };
 
@@ -68,7 +70,6 @@ describe("summarizeChain", () => {
   it("reports the fastest run's times", () => {
     const summary = summarizeChain([run(1, 120_000, 100), run(2, 60_000, 50), run(3, 90_000, 75)]);
 
-    expect(summary.runs).toBe(3);
     expect(summary.bestDurationMs).toBe(60_000);
     // Seconds on the log, milliseconds out.
     expect(summary.bestQuestElapsedMs).toBe(50_000);
@@ -137,5 +138,32 @@ describe("chainKey", () => {
     expect(chainKey(row(9, 7))).toBe(7);
     expect(chainKey(row(7))).toBe(7);
     expect(chainKey(row(5, null))).toBe(5);
+  });
+});
+
+describe("chainColors", () => {
+  it("colours only the chains, and gives neighbouring ones different hues", () => {
+    // A lone log between two chains: it takes no colour, and — the point of
+    // counting positions over chains rather than groups — it does not advance
+    // the palette either, so the two chains still differ.
+    const groups = groupRepeatChains([row(9, 7), row(7), row(5), row(4, 2), row(2)]);
+    const colors = chainColors(groups);
+
+    expect(colors.get(5)).toBeUndefined();
+    expect(colors.get(7)).toBe(PLAYER_COLORS[0]);
+    expect(colors.get(2)).toBe(PLAYER_COLORS[1]);
+  });
+
+  it("wraps back to the start once the palette runs out", () => {
+    // One chain per palette slot, plus one more.
+    const rows = Array.from({ length: PLAYER_COLORS.length + 1 }, (_, chain) => [
+      row(chain * 2 + 2, chain * 2 + 1),
+      row(chain * 2 + 1),
+    ]).flat();
+    const colors = chainColors(groupRepeatChains(rows));
+
+    expect(colors.size).toBe(PLAYER_COLORS.length + 1);
+    expect(colors.get(1)).toBe(PLAYER_COLORS[0]);
+    expect(colors.get(PLAYER_COLORS.length * 2 + 1)).toBe(PLAYER_COLORS[0]);
   });
 });

--- a/src/pages/logs/repeatChains.test.ts
+++ b/src/pages/logs/repeatChains.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { chainKey, groupRepeatChains } from "./repeatChains";
+import { chainKey, chainLatestTime, groupRepeatChains, summarizeChain } from "./repeatChains";
 
 type Row = { id: number; repeatGroup?: number | null };
 
@@ -55,6 +55,80 @@ describe("groupRepeatChains", () => {
     expect(groups.map((g) => g.leader.id)).toEqual([9, 4]);
     expect(groups[0].rest.map((r) => r.id)).toEqual([7]);
     expect(groups[1].rest.map((r) => r.id)).toEqual([2]);
+  });
+});
+
+describe("summarizeChain", () => {
+  const run = (id: number, duration: number, questElapsedTime: number | null = null) => ({
+    id,
+    duration,
+    questElapsedTime,
+  });
+
+  it("reports the fastest run's times", () => {
+    const summary = summarizeChain([run(1, 120_000, 100), run(2, 60_000, 50), run(3, 90_000, 75)]);
+
+    expect(summary.runs).toBe(3);
+    expect(summary.bestDurationMs).toBe(60_000);
+    // Seconds on the log, milliseconds out.
+    expect(summary.bestQuestElapsedMs).toBe(50_000);
+  });
+
+  it("takes each best from its own run", () => {
+    // Run 3 ended fastest on the clock, run 2 cleared fastest in game time, so
+    // the two figures come from different rows.
+    const summary = summarizeChain([run(1, 120_000, 100), run(2, 90_000, 50), run(3, 60_000, 75)]);
+
+    expect(summary.bestDurationMs).toBe(60_000);
+    expect(summary.bestQuestElapsedMs).toBe(50_000);
+  });
+
+  it("names the run that set each best", () => {
+    // Different runs: run 3 ended fastest on the clock, run 2 cleared fastest
+    // in game time.
+    const summary = summarizeChain([run(1, 120_000, 100), run(2, 90_000, 50), run(3, 60_000, 75)]);
+
+    expect(summary.bestDurationId).toBe(3);
+    expect(summary.bestQuestElapsedId).toBe(2);
+  });
+
+  it("gives a tie to the first run in display order", () => {
+    const summary = summarizeChain([run(1, 60_000, 50), run(2, 60_000, 50)]);
+
+    expect(summary.bestDurationId).toBe(1);
+    expect(summary.bestQuestElapsedId).toBe(1);
+  });
+
+  it("never reports a placeholder in-game time as the best", () => {
+    // 1s is what logs recorded before the timer was read correctly stored; it
+    // is not a run's time, so it cannot win "best" — reported, it would claim a
+    // record nobody ran.
+    const summary = summarizeChain([run(1, 60_000, 100), run(2, 60_000, 1), run(3, 60_000, 200)]);
+
+    expect(summary.bestQuestElapsedMs).toBe(100_000);
+    expect(summary.bestQuestElapsedId).toBe(1);
+  });
+
+  it("reports no in-game time when no run recorded one", () => {
+    const summary = summarizeChain([run(1, 60_000, null), run(2, 30_000, 1)]);
+
+    expect(summary.bestQuestElapsedMs).toBeNull();
+    expect(summary.bestQuestElapsedId).toBeNull();
+    // Wall-clock duration is always present, so it still summarizes.
+    expect(summary.bestDurationMs).toBe(30_000);
+    expect(summary.bestDurationId).toBe(2);
+  });
+});
+
+describe("chainLatestTime", () => {
+  it("takes the most recent run whatever order the rows arrive in", () => {
+    // Under a duration sort the newest run can sit anywhere in the block, so
+    // reading the head of the list would date the chain by the wrong run.
+    expect(chainLatestTime([{ time: 200 }, { time: 300 }, { time: 100 }])).toBe(300);
+  });
+
+  it("is null with no runs to date", () => {
+    expect(chainLatestTime([])).toBeNull();
   });
 });
 

--- a/src/pages/logs/repeatChains.ts
+++ b/src/pages/logs/repeatChains.ts
@@ -1,9 +1,11 @@
 /** Grouping of Repeat Quest chains for the quest list.
  *
  * The backend stamps every later run of a chain with `repeatGroup` = the id of
- * the chain's first run (the first run itself carries null). The list shows a
- * chain collapsed under one visible row.
+ * the chain's first run (the first run itself carries null). The list draws a
+ * chain as a summary row with its runs listed beneath it.
  */
+
+import { hasQuestElapsedTime } from "@/utils";
 
 type ChainRow = { id: number; repeatGroup?: number | null };
 
@@ -35,4 +37,64 @@ export function groupRepeatChains<T extends ChainRow>(logs: T[]): RepeatChainGro
     }
   }
   return groups;
+}
+
+/** A run, as the chain summary reads it. `questElapsedTime` is in SECONDS, the
+ * shape the log carries. */
+type TimedRow = { id: number; duration: number; questElapsedTime?: number | null };
+
+/** What the chain's summary row reports about the runs under it.
+ *
+ * The best, in every time column. A time on the band has to be a time somebody
+ * ran: a total or an average is a figure no row under it holds, and closed —
+ * where the band is the only thing on screen — it sits in the same column as
+ * the standalone runs around it, inviting a comparison it cannot honestly
+ * answer. The best is also what the list places a chain by, so the figure
+ * shown and the reason the block sits where it does are one and the same.
+ *
+ * The in-game times are nullable as a pair: logs recorded before the quest
+ * timer was read correctly (and fights the game never reported one for) store
+ * a placeholder that `hasQuestElapsedTime` rejects, and a chain of only those
+ * has no in-game time to report. Wall-clock duration is always present.
+ */
+export type ChainSummary = {
+  runs: number;
+  bestDurationMs: number;
+  bestQuestElapsedMs: number | null;
+  /** The run that set each best, so opening the chain shows WHERE the band's
+   * figure came from rather than leaving the reader to match two equal times
+   * across the block. Ties go to the first in display order — marking two rows
+   * as "the" best says neither. */
+  bestDurationId: number | null;
+  bestQuestElapsedId: number | null;
+};
+
+export function summarizeChain(runs: TimedRow[]): ChainSummary {
+  // Seconds on the log, milliseconds everywhere the summary is read.
+  const timed = runs.filter((run) => hasQuestElapsedTime(run.questElapsedTime));
+
+  const fastest = <T>(rows: T[], of: (row: T) => number): T | null =>
+    rows.reduce<T | null>((best, row) => (best === null || of(row) < of(best) ? row : best), null);
+
+  const bestDuration = fastest(runs, (run) => run.duration);
+  const bestElapsed = fastest(timed, (run) => run.questElapsedTime as number);
+
+  return {
+    runs: runs.length,
+    bestDurationMs: bestDuration?.duration ?? 0,
+    // Null, not zero: a chain where nothing reported an in-game time has no
+    // best, and 00:00 would read as a clear nobody could have run.
+    bestQuestElapsedMs: bestElapsed === null ? null : (bestElapsed.questElapsedTime as number) * 1000,
+    bestDurationId: bestDuration?.id ?? null,
+    bestQuestElapsedId: bestElapsed?.id ?? null,
+  };
+}
+
+/** When the chain's most recent run happened.
+ *
+ * Taken as the maximum rather than off the head of the list: the rows arrive in
+ * whatever order the user sorted them, and only under the default newest-first
+ * is the leading row the latest one. */
+export function chainLatestTime(runs: { time: number }[]): number | null {
+  return runs.length === 0 ? null : Math.max(...runs.map((run) => run.time));
 }

--- a/src/pages/logs/repeatChains.ts
+++ b/src/pages/logs/repeatChains.ts
@@ -5,7 +5,7 @@
  * chain as a summary row with its runs listed beneath it.
  */
 
-import { hasQuestElapsedTime } from "@/utils";
+import { PLAYER_COLORS, hasQuestElapsedTime } from "@/utils";
 
 type ChainRow = { id: number; repeatGroup?: number | null };
 
@@ -58,7 +58,6 @@ type TimedRow = { id: number; duration: number; questElapsedTime?: number | null
  * has no in-game time to report. Wall-clock duration is always present.
  */
 export type ChainSummary = {
-  runs: number;
   bestDurationMs: number;
   bestQuestElapsedMs: number | null;
   /** The run that set each best, so opening the chain shows WHERE the band's
@@ -80,7 +79,6 @@ export function summarizeChain(runs: TimedRow[]): ChainSummary {
   const bestElapsed = fastest(timed, (run) => run.questElapsedTime as number);
 
   return {
-    runs: runs.length,
     bestDurationMs: bestDuration?.duration ?? 0,
     // Null, not zero: a chain where nothing reported an in-game time has no
     // best, and 00:00 would read as a clear nobody could have run.
@@ -97,4 +95,27 @@ export function summarizeChain(runs: TimedRow[]): ChainSummary {
  * is the leading row the latest one. */
 export function chainLatestTime(runs: { time: number }[]): number | null {
   return runs.length === 0 ? null : Math.max(...runs.map((run) => run.time));
+}
+
+/** A colour per chain, cycled through the party palette — two chains of the
+ * same quest, back to back, are otherwise told apart only by where one block of
+ * identical rows stops and the next begins.
+ *
+ * Positions are counted over CHAINS, so the unchained logs between them do not
+ * advance the palette: letting them would make the sequence look arbitrary and
+ * could land neighbouring chains on the same hue. The same categorical rule
+ * `statusRowColors` follows next door, kept here so it is testable rather than
+ * buried in the page component.
+ *
+ * The palette is shared with player rows for its hues alone — no chain means a
+ * player, and the meter's per-player colour overrides do not reach here. */
+export function chainColors<T extends ChainRow>(groups: RepeatChainGroup<T>[]): Map<number, string> {
+  const colors = new Map<number, string>();
+  let position = 0;
+  for (const group of groups) {
+    if (group.rest.length === 0) continue;
+    colors.set(chainKey(group.leader), PLAYER_COLORS[position % PLAYER_COLORS.length]);
+    position += 1;
+  }
+  return colors;
 }

--- a/src/pages/toolbox/CheatAudit.test.tsx
+++ b/src/pages/toolbox/CheatAudit.test.tsx
@@ -144,7 +144,6 @@ describe("CheatAudit", () => {
           `ui.legality.limit.wrightstoneTraitLevel:${JSON.stringify({
             observed: allowed === 20 ? 30 : 20,
             allowed,
-            chance: "",
           })}`
         )
       ).toBeTruthy();

--- a/src/stores/useMeterSettingsStore.ts
+++ b/src/stores/useMeterSettingsStore.ts
@@ -93,7 +93,13 @@ export const DEFAULT_HEADER_SEGMENTS: HeaderSegment[] = [
  * `classic` is the original four-tab view (Overview / SBA / Equipment / Builds),
  * kept because it is what every existing user has muscle memory for, and because
  * the redesign changes how a number is reached, not just how it looks. Both are
- * maintained; only `analysis` gains new metrics. */
+ * maintained; only `analysis` gains new metrics.
+ *
+ * DEV BUILDS ONLY at present. `analysis` is unfinished, so `ViewPage` ignores
+ * this setting entirely outside dev and renders Classic — see the guard there
+ * for why it ignores rather than defaults. The stored value therefore governs
+ * nothing in a release build; leave it as it is rather than "fixing" the
+ * default below to match what users see. */
 export type LogsViewMode = "analysis" | "classic";
 
 interface MeterSettings {

--- a/src/types.ts
+++ b/src/types.ts
@@ -866,6 +866,7 @@ export interface HookStatusSnapshot {
  * gear line the limit sits under.) */
 export type LegalityRule =
   | "wrightstoneTraitLevel"
+  | "wrightstoneTrait"
   | "sigilTraitLevel"
   | "sigilLockedPair"
   | "sigilQuestLockedTrait"

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -13,6 +13,7 @@ import {
   EMPTY_ID,
   OVERMASTERY_EFFECT_IDS,
   SKILLBOARD_CATEGORIES,
+  SUMMON_ATTACK_ACTION_ID,
   barWidth,
   checklistLevel,
   checklistStatus,
@@ -50,9 +51,13 @@ import {
   type BonusSource,
 } from "./utils";
 
-const makeSkill = (actionType: SkillState["actionType"], totalDamage: number): SkillState => ({
+const makeSkill = (
+  actionType: SkillState["actionType"],
+  totalDamage: number,
+  childCharacterType: SkillState["childCharacterType"] = "Pl0000"
+): SkillState => ({
   actionType,
-  childCharacterType: "Pl0000",
+  childCharacterType,
   hits: 1,
   minDamage: totalDamage,
   maxDamage: totalDamage,
@@ -140,6 +145,42 @@ describe("utils", () => {
       const { eligible, overall } = computeSupPercentage(player);
       expect(eligible).toBeCloseTo(20);
       expect(overall).toBeCloseTo((200 / 10000) * 100);
+    });
+
+    it("excludes Ferry's pets and Umlauf from the eligible base", () => {
+      // The ghosts' hits report as Normal skills but no supplementary proc is ever
+      // logged under their bodies, so counting them only dilutes the proc-quality
+      // number: log 1668 read 13.4% with them in the base and 29.5% without.
+      const player = makePlayer([
+        makeSkill({ Normal: 1 }, 1000),
+        makeSkill({ Normal: 9995 }, 4000, "Pl0700Ghost"),
+        makeSkill({ Normal: 1700 }, 2000, "Pl0700GhostSatellite"),
+        makeSkill({ SupplementaryDamage: 1 }, 200),
+      ]);
+      const { eligible, overall } = computeSupPercentage(player);
+      expect(eligible).toBeCloseTo(20);
+      expect(overall).toBeCloseTo((200 / 7200) * 100);
+    });
+
+    it("excludes summon hits from the eligible base", () => {
+      // Summons are called, not swung: no supplementary damage is ever logged under
+      // a summon body, and one Primal Burst can outweigh a whole rotation.
+      const player = makePlayer([
+        makeSkill({ Normal: 1 }, 1000),
+        makeSkill({ Normal: SUMMON_ATTACK_ACTION_ID }, 9000, { Unknown: 0x5418b8f8 }),
+        makeSkill({ SupplementaryDamage: 1 }, 200),
+      ]);
+      expect(computeSupPercentage(player).eligible).toBeCloseTo(20);
+    });
+
+    it("keeps a transformed body's own hits eligible", () => {
+      // Id's transformation (Pl2000) and Cagliostro's clone do proc supplementary
+      // damage — the exclusion is for pets and summons, not every child body.
+      const player = makePlayer([
+        makeSkill({ Normal: 1000 }, 4000, "Pl2000"),
+        makeSkill({ SupplementaryDamage: 1 }, 800),
+      ]);
+      expect(computeSupPercentage(player).eligible).toBeCloseTo(20);
     });
 
     it("caps out at +60% when every hit procs all three sources", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,12 +95,35 @@ export const isSkillGroup = (
 ): row is ComputedSkillGroup & { actionType: { Group: string } } =>
   typeof row.actionType === "object" && Object.hasOwn(row.actionType, "Group");
 
+/** Bodies that swing on a player's behalf but never proc supplementary damage:
+ * Ferry's ghosts (Geegee/Beebee/Kikiriki/Nicola) and her Umlauf satellite.
+ *
+ * Named bodies only. A player wearing a different body is still the player —
+ * Id's transformation (`Pl2000`) and Cagliostro's clone both proc normally, and
+ * the game logs each proc under the body that earned it, which is how these two
+ * lists were told apart. */
+const SUP_INELIGIBLE_BODIES: readonly string[] = ["Pl0700Ghost", "Pl0700GhostSatellite"];
+
 /**
- * Only Normal skill hits can trigger supplementary damage — Link Attacks, Skybound
- * Arts and damage-over-time cannot. (Groups are frontend merges of Normal skills.)
+ * Whether a breakdown row's damage belongs in the Sup% eligible base.
+ *
+ * Only a player's own Normal skill hits can trigger supplementary damage. Link
+ * Attacks, Skybound Arts and damage-over-time cannot, and neither can the bodies
+ * that fight alongside them: Ferry's pets and summons deal Normal-typed damage
+ * but no proc is ever logged under either, so counting their damage only dilutes
+ * the number. (Groups are frontend merges of Normal skills, scoped to the body
+ * they came from, so the same two tests apply.)
  */
-export const isSupEligibleAction = (actionType: SkillState["actionType"]): boolean =>
-  typeof actionType === "object" && (Object.hasOwn(actionType, "Normal") || Object.hasOwn(actionType, "Group"));
+export const isSupEligibleRow = (skill: SkillRow): boolean => {
+  const { actionType } = skill;
+  if (typeof actionType !== "object") return false;
+  if (!Object.hasOwn(actionType, "Normal") && !Object.hasOwn(actionType, "Group")) return false;
+
+  if (isSummonHit(skill)) return false;
+  if ((actionType as { Group?: string }).Group === PRIMAL_BURST_GROUP) return false;
+
+  return !SUP_INELIGIBLE_BODIES.includes(String(skill.childCharacterType));
+};
 
 export type SupPercentages = {
   /** Supp damage relative to supp-eligible (Normal skill) damage — the proc-quality
@@ -108,7 +131,7 @@ export type SupPercentages = {
    * and a 100% proc rate this tops out at +60%. */
   eligible: number;
   /** Supp damage as a share of the player's total damage, ineligible sources
-   * (Link Attack, SBA, DoT) included. */
+   * (Link Attack, SBA, DoT, pets, summons) included. */
   overall: number;
 };
 
@@ -121,7 +144,7 @@ export const computeSupPercentage = (player: PlayerState): SupPercentages => {
   for (const skill of player.skillBreakdown) {
     if (isSupplementaryAction(skill.actionType)) {
       suppDamage += skill.totalDamage;
-    } else if (isSupEligibleAction(skill.actionType)) {
+    } else if (isSupEligibleRow(skill)) {
       eligibleDamage += skill.totalDamage;
     }
   }
@@ -824,16 +847,23 @@ export const PRIMAL_BURST_CLASSES: readonly string[] = ["5418b8f8", "32776c5b", 
 /** The skill-group key the three bodies condense into. */
 export const PRIMAL_BURST_GROUP = "primal-burst";
 
+/** True for a hit dealt by a called summon: every one of them reports the same
+ * shared summon-attack action from an unresolved `So####` body, which is what
+ * separates a summon from a player's own alternate body. */
+export const isSummonHit = (skill: SkillRow): boolean => {
+  if (typeof skill.actionType !== "object" || !Object.hasOwn(skill.actionType, "Normal")) return false;
+  if ((skill.actionType as { Normal: number }).Normal !== SUMMON_ATTACK_ACTION_ID) return false;
+
+  return summonBodyHash(skill.childCharacterType) !== null;
+};
+
 /** True for a summon hit dealt by one of the Primal Burst bodies. Owns the
  * hash-format detail (lowercase, zero-padded to eight) so callers never
  * re-derive it. */
 export const isPrimalBurstHit = (skill: SkillRow): boolean => {
-  if (typeof skill.actionType !== "object" || !Object.hasOwn(skill.actionType, "Normal")) return false;
-  if ((skill.actionType as { Normal: number }).Normal !== SUMMON_ATTACK_ACTION_ID) return false;
+  if (!isSummonHit(skill)) return false;
 
-  const bodyHash = summonBodyHash(skill.childCharacterType);
-
-  return bodyHash !== null && PRIMAL_BURST_CLASSES.includes(bodyHash);
+  return PRIMAL_BURST_CLASSES.includes(summonBodyHash(skill.childCharacterType)!);
 };
 
 /** The body-class hash of a summon hit, or null when the source is a real

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,37 +92,57 @@ export const isSupplementaryAction = (actionType: SkillState["actionType"]): boo
  */
 export const isSkillGroup = (
   row: ComputedSkillGroup | ComputedSkillState
-): row is ComputedSkillGroup & { actionType: { Group: string } } =>
+): row is ComputedSkillGroup & { actionType: { Group: string } } => hasGroupAction(row);
+
+/** The group test on its own, over the two fields any hit carries.
+ *
+ * `isSkillGroup` narrows to a full `ComputedSkillGroup`, which is only truthful
+ * for the rows the breakdown builds; callers holding a bare `SkillRow` need the
+ * same shape test without that promise. Both spell it once, here. */
+const hasGroupAction = (row: SkillRow): row is SkillRow & { actionType: { Group: string } } =>
   typeof row.actionType === "object" && Object.hasOwn(row.actionType, "Group");
 
-/** Bodies that swing on a player's behalf but never proc supplementary damage:
- * Ferry's ghosts (Geegee/Beebee/Kikiriki/Nicola) and her Umlauf satellite.
+/** Bodies that swing on a player's behalf but are not the player: Ferry's
+ * ghosts (Geegee/Beebee/Kikiriki/Nicola) and her Umlauf satellite.
  *
  * Named bodies only. A player wearing a different body is still the player —
- * Id's transformation (`Pl2000`) and Cagliostro's clone both proc normally, and
- * the game logs each proc under the body that earned it, which is how these two
- * lists were told apart. */
-const SUP_INELIGIBLE_BODIES: readonly string[] = ["Pl0700Ghost", "Pl0700GhostSatellite"];
+ * Id's transformation (`Pl2000`) and Cagliostro's clone both proc supplementary
+ * damage normally, and the game logs each proc under the body that earned it,
+ * which is how these two lists were told apart. */
+const COMPANION_BODIES: readonly string[] = ["Pl0700Ghost", "Pl0700GhostSatellite"];
+
+/**
+ * Whether a hit came from something fighting alongside the player rather than
+ * from the player's own body: a called summon, a Primal Burst, or one of
+ * Ferry's named pets.
+ *
+ * One question with one answer. The three tests were asked separately at the
+ * one call site that needed them, which left the concept unnamed and gave the
+ * next metric that wants it nothing to call.
+ */
+export const isCompanionHit = (skill: SkillRow): boolean => {
+  if (isSummonHit(skill)) return true;
+  if (hasGroupAction(skill) && skill.actionType.Group === PRIMAL_BURST_GROUP) return true;
+
+  return COMPANION_BODIES.includes(String(skill.childCharacterType));
+};
 
 /**
  * Whether a breakdown row's damage belongs in the Sup% eligible base.
  *
  * Only a player's own Normal skill hits can trigger supplementary damage. Link
- * Attacks, Skybound Arts and damage-over-time cannot, and neither can the bodies
- * that fight alongside them: Ferry's pets and summons deal Normal-typed damage
- * but no proc is ever logged under either, so counting their damage only dilutes
- * the number. (Groups are frontend merges of Normal skills, scoped to the body
- * they came from, so the same two tests apply.)
+ * Attacks, Skybound Arts and damage-over-time cannot, and neither can the
+ * companions: pets and summons deal Normal-typed damage but no proc is ever
+ * logged under either, so counting their damage only dilutes the number.
+ * (Groups are frontend merges of Normal skills, scoped to the body they came
+ * from, so the same two tests apply.)
  */
 export const isSupEligibleRow = (skill: SkillRow): boolean => {
   const { actionType } = skill;
   if (typeof actionType !== "object") return false;
-  if (!Object.hasOwn(actionType, "Normal") && !Object.hasOwn(actionType, "Group")) return false;
+  if (!Object.hasOwn(actionType, "Normal") && !hasGroupAction(skill)) return false;
 
-  if (isSummonHit(skill)) return false;
-  if ((actionType as { Group?: string }).Group === PRIMAL_BURST_GROUP) return false;
-
-  return !SUP_INELIGIBLE_BODIES.includes(String(skill.childCharacterType));
+  return !isCompanionHit(skill);
 };
 
 export type SupPercentages = {
@@ -847,23 +867,30 @@ export const PRIMAL_BURST_CLASSES: readonly string[] = ["5418b8f8", "32776c5b", 
 /** The skill-group key the three bodies condense into. */
 export const PRIMAL_BURST_GROUP = "primal-burst";
 
-/** True for a hit dealt by a called summon: every one of them reports the same
- * shared summon-attack action from an unresolved `So####` body, which is what
- * separates a summon from a player's own alternate body. */
-export const isSummonHit = (skill: SkillRow): boolean => {
-  if (typeof skill.actionType !== "object" || !Object.hasOwn(skill.actionType, "Normal")) return false;
-  if ((skill.actionType as { Normal: number }).Normal !== SUMMON_ATTACK_ACTION_ID) return false;
+/** The body-class hash of a called summon's hit, or null when the hit is not
+ * one: every summon reports the same shared summon-attack action from an
+ * unresolved `So####` body, which is what separates a summon from a player's
+ * own alternate body.
+ *
+ * Answers with the hash rather than a boolean so a caller that needs to know
+ * WHICH summon does not re-run the test to find out. */
+const summonHitBodyHash = (skill: SkillRow): string | null => {
+  if (typeof skill.actionType !== "object" || !Object.hasOwn(skill.actionType, "Normal")) return null;
+  if ((skill.actionType as { Normal: number }).Normal !== SUMMON_ATTACK_ACTION_ID) return null;
 
-  return summonBodyHash(skill.childCharacterType) !== null;
+  return summonBodyHash(skill.childCharacterType);
 };
+
+/** True for a hit dealt by a called summon. */
+export const isSummonHit = (skill: SkillRow): boolean => summonHitBodyHash(skill) !== null;
 
 /** True for a summon hit dealt by one of the Primal Burst bodies. Owns the
  * hash-format detail (lowercase, zero-padded to eight) so callers never
  * re-derive it. */
 export const isPrimalBurstHit = (skill: SkillRow): boolean => {
-  if (!isSummonHit(skill)) return false;
+  const bodyHash = summonHitBodyHash(skill);
 
-  return PRIMAL_BURST_CLASSES.includes(summonBodyHash(skill.childCharacterType)!);
+  return bodyHash !== null && PRIMAL_BURST_CLASSES.includes(bodyHash);
 };
 
 /** The body-class hash of a summon hit, or null when the source is a real

--- a/src/violations.test.ts
+++ b/src/violations.test.ts
@@ -15,6 +15,7 @@ const t = render as never;
  * added in Rust fails `tsc` here until someone says what it is a violation of. */
 const EXPECTED: Record<LegalityRule, Violation> = {
   wrightstoneTraitLevel: "impossibleWrightstone",
+  wrightstoneTrait: "impossibleWrightstone",
   sigilTraitLevel: "impossibleSigil",
   sigilLockedPair: "impossibleSigil",
   sigilQuestLockedTrait: "impossibleSigil",

--- a/src/violations.ts
+++ b/src/violations.ts
@@ -40,6 +40,7 @@ export const VIOLATIONS: Violation[] = [
 
 const BY_RULE: Record<LegalityRule, Violation> = {
   wrightstoneTraitLevel: "impossibleWrightstone",
+  wrightstoneTrait: "impossibleWrightstone",
   sigilTraitLevel: "impossibleSigil",
   sigilLockedPair: "impossibleSigil",
   sigilQuestLockedTrait: "impossibleSigil",


### PR DESCRIPTION
## Summary

A Repeat Quest chain used to be drawn by promoting its first run to speak for the rest, with a `×N` badge beside the date — so every figure on the visible row belonged to one run rather than to the session. And because the pager counted rows, a chain straddling a page boundary rendered as two blocks: two different "fastest run"s, and a different colour on each side of the break.

Three commits:

- **`fix(analysis)`** — keep pets and summons out of the Sup% eligible base. Ferry's ghosts, her Umlauf satellite and every called summon deal Normal-typed damage but never proc supplementary damage, so counting them only diluted the proc-quality figure (log 1668: 13.4% → 29.5%). A transformed player is still the player — Id's `Pl2000` and Cagliostro's clone stay eligible. `isSupEligibleAction` becomes `isSupEligibleRow`, since the action type alone can't answer this.
- **`feat(logs)` backend** — a page now holds a fixed number of *chains*, and every run in them is fetched whole. A chain is placed by the run that would come first on its own under the chosen sort (fastest ascending, slowest descending; time is always the latest run, since that's the date the band prints). Sorting by in-game time stops treating the stored 1s placeholder as the fastest clear in the database.
- **`feat(logs)` frontend** — the chain gets a summary row of its own: the chain's best times, its most recent date, and blanks where a chain has no single answer (cleared mark, View). Opening it marks the run that set each best in the same accent the band wears. Chains start closed, the whole band toggles, one tick selects every run, and the block is drawn as one object via a coloured spine cycled through the party palette.

Also: the pager moves above the table (the list now varies in height), and the failed-quest mark becomes ✕ to match the ✓ beside it.

## Test plan

Automated, all run on this branch:

- [x] `npx vitest run` — 119 files, 1157 tests pass
- [x] `cargo test -p gbfr-logs --lib db::logs` — 14/14 pass, including 9 new cases covering chain paging, chain placement per sort column/direction, contiguity when an unrelated log sorts mid-chain, and the in-game-time placeholder
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `cargo clippy -p gbfr-logs` — no new warnings (the `get_logs` too-many-arguments warning predates this branch)

Manual, against a live log history:

- [ ] a chain that would straddle a page boundary arrives whole, and page 2 starts at the next chain
- [ ] sorting by duration and by in-game time, both directions, puts each chain where its best/worst run belongs
- [ ] the pager's page count matches the pages the list can actually fill
- [ ] expanding a chain shows the run whose time the band was reporting
- [ ] ticking a chain's checkbox selects every run in it, and deleting the selection removes the whole session

🤖 Generated with [Claude Code](https://claude.com/claude-code)