### PR TITLE
feat: display a purely lucky player as Blessed by RNG, in gold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ version without a section here, and the section body becomes the GitHub
 release body — which the in-app update prompt shows as patch notes. Renders
 markdown in the app.
 
+## 1.12.9
+
+## Notes
+
+- The Perfect Summon rule is no longer classified as a "cheat". Instead, players with Perfect Summons will be displayed in **gold** color because they are extremely lucky ✨
+
 ## 1.12.8
 
 ### Notes

--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -279,6 +279,7 @@
       "open-log": "open",
       "detail-unavailable": "This fight's gear could not be loaded, so the items can't be named.",
       "player-flagged": "This build was flagged",
+      "player-lucky": "Blessed by RNG",
       "limit": {
         "wrightstoneTraitLevel": "max {{allowed}}",
         "wrightstoneTrait": "can't roll here",
@@ -300,7 +301,7 @@
         "impossibleWrightstone": "Impossible Wrightstone",
         "impossibleSummon": "Impossible Summon",
         "impossibleOvermastery": "Impossible Overmastery",
-        "perfectSummons": "Perfect Summons",
+        "perfectSummons": "Blessed by RNG",
         "perfectOvermasteries": "Perfect Overmasteries",
         "masterTraits": "Master Traits"
       },

--- a/src/components/FlaggedGear.tsx
+++ b/src/components/FlaggedGear.tsx
@@ -6,6 +6,7 @@ import { describeLimit } from "@/legality";
 import { markedLines } from "@/legalityLines";
 import { LegalityFinding } from "@/types";
 import { translateTraitId } from "@/utils";
+import { TONE_COLOR, findingsTone } from "@/violations";
 
 import { FindingsExplanation } from "./LegalityMark";
 
@@ -87,9 +88,15 @@ export const FlaggedGear = ({
   const marks = findings.map((finding) => ({ finding, ...markedLines(finding, lines) }));
   const markedAnywhere = new Set(marks.flatMap((mark) => mark.lines));
 
-  // Red says WHICH line. The heading only takes it when no line did — otherwise
-  // it repeats what the line below already says.
-  const headingRed = findings.length > 0 && markedAnywhere.size === 0;
+  // The colour says WHICH line, and its tone says what kind of claim marked it:
+  // red for a cheat, gold for pure luck — with a cheat winning when both mark
+  // the same line, since luck does not soften proof.
+  const lineTone = (index: number) =>
+    findingsTone(marks.filter((mark) => mark.lines.includes(index)).map((mark) => mark.finding));
+
+  // The heading only takes the mark when no line did — otherwise it repeats
+  // what the line below already says.
+  const headingTone = markedAnywhere.size === 0 ? findingsTone(findings) : undefined;
 
   /** The phrases for a line, or for the heading when `index` is omitted. Empty
    * unless this surface prints them beside the gear. */
@@ -108,7 +115,12 @@ export const FlaggedGear = ({
             otherwise invisible to anything but a human eye — including the
             tests that keep the two surfaces marking the same thing. */}
         {/* eslint-disable-next-line i18next/no-literal-string -- already-translated item name */}
-        <Text size="xs" fw={nameWeight} c={headingRed ? "red" : undefined} data-flagged={headingRed || undefined}>
+        <Text
+          size="xs"
+          fw={nameWeight}
+          c={headingTone && TONE_COLOR[headingTone]}
+          data-flagged={headingTone !== undefined || undefined}
+        >
           {name}
         </Text>
         {limits().map((limit, index) => (
@@ -117,24 +129,22 @@ export const FlaggedGear = ({
           </Text>
         ))}
       </Group>
-      {lines.map((line, index) => (
-        <Group key={index} gap={10} wrap="wrap" pl={9}>
-          {/* eslint-disable-next-line i18next/no-literal-string -- already-translated trait line */}
-          <Text
-            size="xs"
-            fw={300}
-            c={markedAnywhere.has(index) ? "red" : undefined}
-            data-flagged={markedAnywhere.has(index) || undefined}
-          >
-            {`- ${line.text}`}
-          </Text>
-          {limits(index).map((limit, limitIndex) => (
-            <Text size="xs" key={limitIndex}>
-              {limit}
+      {lines.map((line, index) => {
+        const tone = lineTone(index);
+        return (
+          <Group key={index} gap={10} wrap="wrap" pl={9}>
+            {/* eslint-disable-next-line i18next/no-literal-string -- already-translated trait line */}
+            <Text size="xs" fw={300} c={tone && TONE_COLOR[tone]} data-flagged={tone !== undefined || undefined}>
+              {`- ${line.text}`}
             </Text>
-          ))}
-        </Group>
-      ))}
+            {limits(index).map((limit, limitIndex) => (
+              <Text size="xs" key={limitIndex}>
+                {limit}
+              </Text>
+            ))}
+          </Group>
+        );
+      })}
       {children}
     </Box>
   );

--- a/src/components/LegalityMark.tsx
+++ b/src/components/LegalityMark.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { LegalityFinding } from "@/types";
+import { TONE_COLOR, findingsTone } from "@/violations";
 
 import { FindingDetail } from "./FindingDetail";
 
@@ -43,10 +44,11 @@ export const FindingsExplanation = ({ findings, title }: { findings: LegalityFin
  * is being claimed. With no findings it renders its children untouched and adds
  * no tooltip, so a clean build looks exactly as it did before.
  *
- * There is one colour. Severity used to split this red/yellow, but "Impossible"
- * and "Improbable" are adjectives a reader has to decode; what actually
- * separates proof from luck is the claim itself, so the odds line below carries
- * it instead.
+ * Two colours, drawn from the findings' tone: red for a cheat, gold for a set
+ * that is nothing but luck ("Blessed by RNG"). Not the old red/yellow severity
+ * split — that graded HOW damning the same accusation was, which a reader
+ * could not decode. Gold is a different claim entirely: nothing here is
+ * impossible, this person just rolled it.
  */
 export const LegalityMark = ({
   findings,
@@ -59,13 +61,14 @@ export const LegalityMark = ({
   title?: string;
   children: ReactNode;
 }) => {
-  if (findings.length === 0) return <>{children}</>;
+  const tone = findingsTone(findings);
+  if (tone === undefined) return <>{children}</>;
 
   return (
     <Tooltip multiline w={340} withArrow color="dark" label={<FindingsExplanation findings={findings} title={title} />}>
       {/* `span` keeps the wrapped node's own layout: these wrap table cells,
           headings and inline text alike, so the mark must not introduce a box. */}
-      <Text span c="red" inherit style={{ cursor: "help" }}>
+      <Text span c={TONE_COLOR[tone]} inherit style={{ cursor: "help" }}>
         {children}
       </Text>
     </Tooltip>
@@ -79,8 +82,14 @@ export const LegalityMark = ({
 export const LegalityPlayerName = ({ findings, children }: { findings: LegalityFinding[]; children: ReactNode }) => {
   const { t } = useTranslation();
 
+  // A gold name gets a gold heading: "this build was flagged" over a mark that
+  // means "extremely lucky" would take back what the colour just said.
+  const tone = findingsTone(findings);
+  const title =
+    tone === undefined ? undefined : t(tone === "lucky" ? "ui.legality.player-lucky" : "ui.legality.player-flagged");
+
   return (
-    <LegalityMark findings={findings} title={findings.length > 0 ? t("ui.legality.player-flagged") : undefined}>
+    <LegalityMark findings={findings} title={title}>
       {children}
     </LegalityMark>
   );

--- a/src/components/usePlayerRow.legality.test.ts
+++ b/src/components/usePlayerRow.legality.test.ts
@@ -14,15 +14,24 @@ const finding = (): LegalityFinding => ({
   odds: null,
 });
 
-/** A long-odds report rather than a hard breach. It must colour EXACTLY as the
- * breach does: the meter has no room to explain the difference, and a second
- * colour a reader cannot interpret is just a second kind of accusation. */
-const longOdds = (): LegalityFinding => ({
+/** A full set of perfect summons — the one finding that reads as luck rather
+ * than cheating, and so colours gold instead of red. */
+const perfectSummons = (): LegalityFinding => ({
   rule: "summonPerfectCount",
   subject: { kind: "summons" },
   observed: { kind: "count", value: 3 },
   allowed: { kind: "none" },
   odds: 4.7e-7,
+});
+
+/** The OTHER long-odds report. It stays red: only perfect summons earns the
+ * gold, and a second unexplained colour would be a second kind of accusation. */
+const perfectOvermasteries = (): LegalityFinding => ({
+  rule: "overmasteryAllMaxed",
+  subject: { kind: "overmasteries" },
+  observed: { kind: "count", value: 4 },
+  allowed: { kind: "none" },
+  odds: 1.2e-5,
 });
 
 /** Enough of a player for the hook; the row's damage columns are not under
@@ -48,8 +57,22 @@ describe("usePlayerRow legality colour", () => {
     expect(render([[finding()], [], [], []]).current.legalityColor).toBe("red");
   });
 
-  it("colours a long-odds report exactly as it colours a hard breach", () => {
-    expect(render([[longOdds()], [], [], []]).current.legalityColor).toBe("red");
+  /** "Blessed by RNG": a player whose ONLY finding is a full set of perfect
+   * summons is a farmer, and their name says so in gold rather than red. */
+  it("colours a purely lucky player gold", () => {
+    expect(render([[perfectSummons()], [], [], []]).current.legalityColor).toBe("yellow");
+  });
+
+  /** Luck does not launder a modded build: one real breach beside the perfect
+   * summons and the row is red like any other cheat. */
+  it("colours a lucky player red once a real breach joins", () => {
+    expect(render([[perfectSummons(), finding()], [], [], []]).current.legalityColor).toBe("red");
+  });
+
+  /** Only perfect summons earns the gold; all-maxed overmasteries is a ladder a
+   * few rerolls can walk, and stays a cheat read. */
+  it("colours the other long-odds report red", () => {
+    expect(render([[perfectOvermasteries()], [], [], []]).current.legalityColor).toBe("red");
   });
 
   it("leaves a clean player uncoloured", () => {

--- a/src/components/usePlayerRow.ts
+++ b/src/components/usePlayerRow.ts
@@ -4,6 +4,7 @@ import { useShallow } from "zustand/react/shallow";
 import { useMeterSettingsStore } from "@/stores/useMeterSettingsStore";
 import { ComputedPlayerState, LegalityFinding, MeterColumns, PlayerData, visibleColumns } from "@/types";
 import { PLAYER_COLORS, computeSupPercentage, humanizeNumbers, resolvePlayerColor } from "@/utils";
+import { TONE_COLOR, findingsTone } from "@/violations";
 
 export type ColumnValue = {
   value: string | number;
@@ -60,12 +61,13 @@ export const usePlayerRow = (
   // narrower choice under it, and on streamer mode — which hides names
   // precisely so nothing about a player reaches the stream.
   //
-  // One colour, not two: the meter has no room to explain the difference
-  // between proof and long odds, and a yellow that a reader cannot interpret
-  // is just a second kind of accusation.
+  // Red for a cheat; gold when everything against the build is luck (a full
+  // set of perfect summons). The gates apply to both — gold is a nicer thing
+  // to say about someone, but it is still saying something.
+  const tone = findingsTone(legality?.[partySlotIndex] ?? []);
   const legalityColor =
-    show_flagged_builds && highlight_illegal_builds && !streamer_mode && (legality?.[partySlotIndex]?.length ?? 0) > 0
-      ? "red"
+    show_flagged_builds && highlight_illegal_builds && !streamer_mode && tone !== undefined
+      ? TONE_COLOR[tone]
       : undefined;
 
   const [totalDamage, totalDamageUnit] = humanizeNumbers(player.totalDamage);

--- a/src/pages/toolbox/CheatAudit.tsx
+++ b/src/pages/toolbox/CheatAudit.tsx
@@ -26,7 +26,7 @@ import { Link } from "react-router-dom";
 
 import { LegalityFlaggedPlayer, LegalitySweepProgress } from "@/types";
 import { epochToLocalTime, translateCharacterType, translateQuestId } from "@/utils";
-import { Violation, violationLabel } from "@/violations";
+import { TONE_COLOR, Violation, violationLabel, violationTone } from "@/violations";
 
 import { FindingDetail } from "@/components/FindingDetail";
 import { AuditFilters, DEFAULT_FILTERS, applyFilters, auditRows, caseFor, playerKey } from "./auditRows";
@@ -50,15 +50,17 @@ const PAGE_HEIGHT = "calc(100vh - var(--app-shell-header-height, 50px) - var(--m
 
 /** A violation, named.
  *
- * One colour for all of them. There used to be two — red for proof, yellow for
- * long odds — but "Impossible" and "Improbable" are adjectives a reader has to
- * decode, and the claim itself does that job better: `max 20` reads as
- * impossible, `1 in 950 rolls` reads as luck. */
+ * Red for every cheat — the old red/yellow split graded HOW damning the same
+ * accusation was, which a reader has to decode, and the claim itself does that
+ * job better: `max 20` reads as impossible. Gold is not that split come back:
+ * it marks the one violation that is not an accusation at all ("Blessed by
+ * RNG"), and it keeps the colour beside every player it applies to, cheat or
+ * not. */
 const ViolationChip = ({ violation }: { violation: Violation }) => {
   const { t } = useTranslation();
 
   return (
-    <Badge size="sm" variant="light" color="red" style={{ textTransform: "none" }}>
+    <Badge size="sm" variant="light" color={TONE_COLOR[violationTone(violation)]} style={{ textTransform: "none" }}>
       {violationLabel(t, violation)}
     </Badge>
   );
@@ -263,13 +265,23 @@ const CheatAuditPage = () => {
                     onClick={() => setSelected(row.key)}
                     p={6}
                     style={{
-                      borderLeft: `2px solid ${row.key === selected ? "var(--mantine-color-red-6)" : "transparent"}`,
+                      // The selection bar takes the row's tone: a gold name
+                      // picked out by a red bar would re-accuse the person the
+                      // colour just cleared.
+                      borderLeft: `2px solid ${
+                        row.key === selected
+                          ? `var(--mantine-color-${TONE_COLOR[row.tone ?? "cheat"]}-6)`
+                          : "transparent"
+                      }`,
                       backgroundColor: row.key === selected ? "var(--mantine-color-dark-6)" : undefined,
                       borderRadius: 2,
                     }}
                   >
+                    {/* Gold in the rail too: a page titled "Cheat Audit" listing
+                        a farmer beside the mods is the complaint that created
+                        the tone in the first place. */}
                     {/* eslint-disable-next-line i18next/no-literal-string -- player-entered name */}
-                    <Text size="sm" fw={600} truncate>
+                    <Text size="sm" fw={600} truncate c={row.tone === "lucky" ? TONE_COLOR.lucky : undefined}>
                       {row.displayName || t("ui:characters.ai")}
                     </Text>
                     {/* eslint-disable-next-line i18next/no-literal-string -- already-translated character name */}
@@ -298,7 +310,7 @@ const CheatAuditPage = () => {
                   is reading evidence about never scrolls away from it. */}
               <Box mb={4}>
                 {/* eslint-disable-next-line i18next/no-literal-string -- player-entered name */}
-                <Text size="lg" fw={700}>
+                <Text size="lg" fw={700} c={found.tone === "lucky" ? TONE_COLOR.lucky : undefined}>
                   {player.displayName || t("ui:characters.ai")}
                 </Text>
                 {/* eslint-disable-next-line i18next/no-literal-string -- already-translated character name */}

--- a/src/pages/toolbox/auditRows.test.ts
+++ b/src/pages/toolbox/auditRows.test.ts
@@ -65,6 +65,15 @@ describe("auditRows", () => {
     expect(entry.displayName).toBe("siunaus");
     expect(entry.characterType).toBe("Pl1000");
   });
+
+  /** The rail's read of a person: gold for pure luck, red for anything else —
+   * so a farmer is never listed looking like the cheats around them. */
+  it("reads a purely lucky person as lucky, and anyone else as a cheat", () => {
+    const lucky = player("lucky", [row(1, 100, perfect, 1)]);
+
+    expect(auditRows([lucky])[0].tone).toBe("lucky");
+    expect(auditRows([siunaus])[0].tone).toBe("cheat");
+  });
 });
 
 describe("caseFor", () => {
@@ -146,6 +155,14 @@ describe("caseFor", () => {
    * chips say what is wrong with the build, not how often it was measured. */
   it("summarises what the person is flagged for, each violation once", () => {
     expect(caseFor(siunaus).violations).toEqual(["impossibleSigil", "perfectSummons"]);
+  });
+
+  /** The case reads the same tone as the rail: the pane's heading and the row
+   * that opened it must never disagree about the same person. */
+  it("carries the case's tone, matching the rail's", () => {
+    expect(caseFor(siunaus).tone).toBe("cheat");
+    expect(caseFor(player("lucky", [row(1, 100, perfect, 1)])).tone).toBe("lucky");
+    expect(caseFor(player("empty", [])).tone).toBeUndefined();
   });
 
   /** A person with no findings has no fight to read gear from, and the page

--- a/src/pages/toolbox/auditRows.ts
+++ b/src/pages/toolbox/auditRows.ts
@@ -22,7 +22,7 @@
  */
 
 import { CharacterType, LegalityFinding, LegalityFlaggedPlayer } from "@/types";
-import { VIOLATIONS, Violation, violationOf } from "@/violations";
+import { LegalityTone, VIOLATIONS, Violation, findingsTone, toneOfViolations, violationOf } from "@/violations";
 
 /** One person, as the rail lists them. */
 export type AuditRow = {
@@ -30,6 +30,9 @@ export type AuditRow = {
   displayName: string;
   characterType: CharacterType;
   lastSeen: number;
+  /** How everything against them reads together — "lucky" draws their name
+   * gold, so a farmer is never listed looking like the cheats around them. */
+  tone: LegalityTone | undefined;
 };
 
 /** One flagged fight, as a row of the case's table of contents. */
@@ -74,6 +77,8 @@ export type AuditEvidence = {
  */
 export type AuditCase = {
   violations: Violation[];
+  /** The case's tone as a whole, matching the rail's read of the same person. */
+  tone: LegalityTone | undefined;
   evidence: AuditEvidence[];
   fights: AuditFight[];
   /** Distinct logs the evidence needs, newest fight first. */
@@ -115,6 +120,7 @@ export const auditRows = (players: LegalityFlaggedPlayer[]): AuditRow[] =>
     displayName: player.displayName,
     characterType: player.characterType,
     lastSeen: player.lastSeen,
+    tone: findingsTone(player.findings.map((row) => row.finding)),
   }));
 
 /** What makes a finding distinct: the same rule against the same slot is the
@@ -159,8 +165,11 @@ export const caseFor = (player: LegalityFlaggedPlayer): AuditCase => {
     (a, b) => (order.get(a) ?? 0) - (order.get(b) ?? 0)
   );
 
+  const violations = violationsIn(evidence.map((row) => row.finding));
+
   return {
-    violations: violationsIn(evidence.map((row) => row.finding)),
+    violations,
+    tone: toneOfViolations(violations),
     evidence,
     fights,
     evidenceLogIds,

--- a/src/violations.test.ts
+++ b/src/violations.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import ui from "../src-tauri/lang/en/ui.json";
 import { LegalityRule } from "./types";
-import { VIOLATIONS, Violation, violationLabel, violationOf } from "./violations";
+import {
+  VIOLATIONS,
+  Violation,
+  findingsTone,
+  toneOfViolations,
+  violationLabel,
+  violationOf,
+  violationTone,
+} from "./violations";
 
 const render = (key: string): string => {
   const path = key.replace(/^ui\./, "").split(".");
@@ -64,8 +72,53 @@ describe("violationLabel", () => {
 
   it("names them the way the reader would say them", () => {
     expect(violationLabel(t, "impossibleSigil")).toBe("Impossible Sigil");
-    expect(violationLabel(t, "perfectSummons")).toBe("Perfect Summons");
     expect(violationLabel(t, "masterTraits")).toBe("Master Traits");
+  });
+
+  /** Not "Perfect Summons": that name filed a farmer's luck under cheating,
+   * which is the complaint that renamed it. The label is a compliment. */
+  it("names perfect summons as luck, not as a cheat", () => {
+    expect(violationLabel(t, "perfectSummons")).toBe("Blessed by RNG");
+  });
+});
+
+describe("violationTone", () => {
+  it("reads perfect summons as luck", () => {
+    expect(violationTone("perfectSummons")).toBe("lucky");
+  });
+
+  /** Everything else stays a cheat read — including perfect overmasteries,
+   * whose ladder a few rerolls can walk. */
+  it("reads every other violation as cheating", () => {
+    for (const violation of VIOLATIONS.filter((v) => v !== "perfectSummons")) {
+      expect(violationTone(violation)).toBe("cheat");
+    }
+  });
+});
+
+describe("toneOfViolations", () => {
+  it("is lucky only when luck is ALL there is", () => {
+    expect(toneOfViolations(["perfectSummons"])).toBe("lucky");
+  });
+
+  /** One real breach turns the whole set red: luck does not launder a modded
+   * sigil. */
+  it("is a cheat as soon as anything else joins", () => {
+    expect(toneOfViolations(["impossibleSigil", "perfectSummons"])).toBe("cheat");
+  });
+
+  /** An empty set is "not judged", which has no colour — never "clean", and
+   * never lucky. */
+  it("has no tone for an empty set", () => {
+    expect(toneOfViolations([])).toBeUndefined();
+  });
+});
+
+describe("findingsTone", () => {
+  it("reads tone through the rules that computed the findings", () => {
+    expect(findingsTone([{ rule: "summonPerfectCount" }])).toBe("lucky");
+    expect(findingsTone([{ rule: "summonPerfectCount" }, { rule: "sigilTraitLevel" }])).toBe("cheat");
+    expect(findingsTone([])).toBeUndefined();
   });
 });
 

--- a/src/violations.ts
+++ b/src/violations.ts
@@ -10,6 +10,12 @@
  * Proof and long odds never collapse even on the same equipment: "impossible
  * summon" is a mod, "perfect summons" is a farmer's luck, and merging them
  * would turn a report into an accusation.
+ *
+ * That distinction has a colour. Perfect summons is the one violation whose
+ * most likely explanation is a farmer who got there, so it reads gold — a
+ * compliment, "Blessed by RNG" — and a player it is the ONLY thing against
+ * reads gold everywhere their name is marked. One real breach turns them red:
+ * luck does not launder a modded sigil.
  */
 
 import { TFunction } from "i18next";
@@ -57,3 +63,29 @@ const BY_RULE: Record<LegalityRule, Violation> = {
 export const violationOf = (rule: LegalityRule): Violation => BY_RULE[rule];
 
 export const violationLabel = (t: TFunction, violation: Violation): string => t(`ui.legality.violation.${violation}`);
+
+/**
+ * How a violation reads: as cheating, or as luck.
+ *
+ * Only perfect summons is luck. Perfect overmasteries stays a cheat read: its
+ * rolls come from a bounded ladder a few rerolls can walk, so all-maxed is not
+ * the astronomical draw a full set of perfect summons is.
+ */
+export type LegalityTone = "cheat" | "lucky";
+
+export const violationTone = (violation: Violation): LegalityTone =>
+  violation === "perfectSummons" ? "lucky" : "cheat";
+
+/** The tone of a whole set: lucky only when EVERYTHING against it is luck.
+ * Undefined on an empty set — "not judged" has no colour. */
+export const toneOfViolations = (violations: Violation[]): LegalityTone | undefined => {
+  if (violations.length === 0) return undefined;
+  return violations.every((violation) => violationTone(violation) === "lucky") ? "lucky" : "cheat";
+};
+
+export const findingsTone = (findings: { rule: LegalityRule }[]): LegalityTone | undefined =>
+  toneOfViolations(findings.map((finding) => violationOf(finding.rule)));
+
+/** The Mantine colour each tone marks in, so every surface resolves the same
+ * pair and none can invent a third. Yellow is Mantine's gold. */
+export const TONE_COLOR: Record<LegalityTone, "red" | "yellow"> = { cheat: "red", lucky: "yellow" };


### PR DESCRIPTION
## Summary

Players complained that the Perfect Summons violation - which you can only earn by being extraordinarily lucky - was displayed exactly like the cheating violations. This PR gives it its own treatment.

Every legality surface now draws from a violation **tone**: `cheat` (red) or `lucky` (gold). `perfectSummons` is the only lucky violation, and a player's findings read as lucky only when *everything* against them is luck - one real breach keeps them red, since luck does not launder a modded sigil.

- The violation is renamed **"Perfect Summons" → "Blessed by RNG"** (en; zh-CN left to translators, its existing text already reads "but legal")
- Its chip on the Cheat Audit page is gold everywhere, even beside real violations
- A player whose **only** violation is Perfect Summons gets a **gold name** on:
  - the meter overlay (same three gates as before: cheat-audit switch, highlight setting, streamer mode)
  - the quest list's party names
  - the log view's name marks
  - the Cheat Audit rail, detail header, and the rail's selection bar
- The gold name's tooltip heading says "Blessed by RNG" instead of "This build was flagged"
- Gear-line marks in `FlaggedGear` are gold when only the luck rule marks them, red when a real breach marks the same line

**Judgment call:** `perfectOvermasteries` stays a cheat read - its rolls come from a small bounded ladder a few rerolls can walk, so all-maxed is not the astronomical draw a full perfect-summon set is. One line in `violationTone` if we want to flip it later.

## Testing

- New tone tests in `violations.test.ts` (lucky vs cheat, mixed sets, empty sets)
- Meter tests replaced: lucky-only → gold, lucky + breach → red, perfect overmasteries → red (`usePlayerRow.legality.test.ts`)
- Rail/case tone tests in `auditRows.test.ts`
- 109 tests passing across the 8 legality-related suites; `tsc`, `eslint ./src`, and Prettier all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
