### PR TITLE
i18n: clarify zh-CN Sup column wording

### DIFF
--- a/src-tauri/lang/zh-CN/ui.json
+++ b/src-tauri/lang/zh-CN/ui.json
@@ -150,7 +150,7 @@
       "damage-description": "总伤害",
       "damage-percentage": "%",
       "damage-percentage-description": "总伤害占比",
-      "sup-percentage": "追击率",
+      "sup-percentage": "追击",
       "sup-percentage-description": "追击触发的额外伤害",
       "sba": "奥义",
       "sba-description": "实时奥义槽数值",

--- a/src-tauri/lang/zh-CN/ui.json
+++ b/src-tauri/lang/zh-CN/ui.json
@@ -151,7 +151,7 @@
       "damage-percentage": "%",
       "damage-percentage-description": "总伤害占比",
       "sup-percentage": "追击",
-      "sup-percentage-description": "追击触发的额外伤害",
+      "sup-percentage-description": "追击伤害相对于可触发追击的基础伤害比例",
       "sba": "奥义",
       "sba-description": "实时奥义槽数值",
       "total-stun-value": "昏厥",


### PR DESCRIPTION
## Summary

- Changes the zh-CN Sup column label from `追击率` to `追击`.
- Clarifies the description from `追击触发的额外伤害` to `追击伤害相对于可触发追击的基础伤害比例`.

## Rationale

The original English column label is `Sup`, an abbreviation of “Supplementary,” rather than “Supplementary Rate” or “Proc Rate.” The current Chinese label `追击率` may therefore be misunderstood as the activation rate of Supplementary Damage.

As discussed in #83, this column displays the extra damage contributed by Supplementary/Echo effects relative to eligible base damage. `追击` was suggested and agreed upon in that discussion.

The calculation was fixed in v1.12.8, but the zh-CN wording remained unchanged. This PR only updates the label and description and does not modify the calculation.

## Validation

- Confirmed that `src-tauri/lang/zh-CN/ui.json` parses successfully as JSON.
- Ran `git diff --check`.
