### PR TITLE
fix(hook): update BSS RVAs for v2.0.4

### DIFF
--- a/src-hook/src/hooks/player.rs
+++ b/src-hook/src/hooks/player.rs
@@ -376,7 +376,8 @@ const RECORD_MASTER_LEVEL_OFFSET: usize = 0x5B60;
 /// v2.0.3: re-derived 2026-07-31 from the `mov r14,[rip+..]` in the weapon-state
 /// fill `FUN_140a2d8d0` (now at rva 0xa27000-ish), which loads the save root and
 /// the weapon table back to back.
-const SAVE_ROOT_RVA: usize = 0x7c21940; // 2.0.2: 0x7c24980
+/// v2.0.4: +0x1280 with CHARA_POWER / WEAPON_TABLE (paired rip-loads, gap 0x178).
+const SAVE_ROOT_RVA: usize = 0x7c22bc0; // 2.0.3: 0x7c21940; 2.0.2: 0x7c24980
 const EQ_MAP_END: usize = 0x40;
 const EQ_MAP_BUCKETS: usize = 0x50;
 const EQ_MAP_MASK: usize = 0x68;
@@ -446,7 +447,8 @@ const WEAPON_SOURCE_KEY_OFFSET: usize = 0x44;
 /// at +0x00, then the 18-u32 weapon struct (so +0x04 = weapon.tbl Key hash),
 /// validity count at +0x40, the 5 active innate skill-id slots at +0x44.
 /// `FUN_140321e30` copies a column verbatim into record+0x50 / blob+0x50.
-const WEAPON_TABLE_RVA: usize = 0x7c21ab8; // 2.0.2: 0x7c24af8
+/// v2.0.4: +0x1280 with SAVE_ROOT (paired rip-loads, gap 0x178).
+const WEAPON_TABLE_RVA: usize = 0x7c22d38; // 2.0.3: 0x7c21ab8; 2.0.2: 0x7c24af8
 const WS_TABLE_BASE: usize = 0x370;
 const WS_TABLE_ROWS: usize = 32;
 const WS_TABLE_ROW_STRIDE: usize = 0x680;
@@ -472,7 +474,9 @@ const WS_TABLE_SKILL_SLOTS: usize = 5;
 /// skillboard query's own `mov rbx,[rip+..]` prologue load and the record
 /// dispatcher's `mov rax,[rip+..]`. This is the global whose staleness silently
 /// emptied master traits after the patch.
-const CHARA_POWER_RVA: usize = 0x7c21a38; // 2.0.2: 0x7c24a78
+/// v2.0.4: +0x1280 with SAVE_ROOT (paired rip-loads, gap 0xF8); stale RVA
+/// again empties master traits in the character config UI.
+const CHARA_POWER_RVA: usize = 0x7c22cb8; // 2.0.3: 0x7c21a38; 2.0.2: 0x7c24a78
 const SB_CHAR_MAP_END: usize = 0x728;
 const SB_CHAR_MAP_BUCKETS: usize = 0x738;
 const SB_CHAR_MAP_MASK: usize = 0x750;

--- a/src-hook/src/hooks/stunnet.rs
+++ b/src-hook/src/hooks/stunnet.rs
@@ -73,9 +73,13 @@ const STUN_MAX_OFFSET: usize = 0xB94;
 /// wrong bucket array and made every online stun unattributable. Reading a
 /// plausible-looking pointer out of the wrong global fails silently, and a
 /// "does it land in BSS" sanity check cannot catch it — the whole region is BSS.
-const NET_ENTITY_MAP_BUCKETS_RVA: usize = 0x7bc3d98; // 2.0.2: 0x7bc6dd8
-const NET_ENTITY_MAP_SENTINEL_RVA: usize = 0x7bc3d88; // 2.0.2: 0x7bc6dc8
-const NET_ENTITY_MAP_MASK_RVA: usize = 0x7bc3db0; // 2.0.2: 0x7bc6df0
+///
+/// v2.0.4: +0x1280 (same shift as SAVE_ROOT / CHARA_POWER). Confirmed by a
+/// resolver window (~0x26ca00) that rip-loads all three with gaps 0x10 / 0x18
+/// unchanged. NETWORK_STUN_SIG and actor+0xB90 still match.
+const NET_ENTITY_MAP_BUCKETS_RVA: usize = 0x7bc5018; // 2.0.3: 0x7bc3d98; 2.0.2: 0x7bc6dd8
+const NET_ENTITY_MAP_SENTINEL_RVA: usize = 0x7bc5008; // 2.0.3: 0x7bc3d88; 2.0.2: 0x7bc6dc8
+const NET_ENTITY_MAP_MASK_RVA: usize = 0x7bc5030; // 2.0.3: 0x7bc3db0; 2.0.2: 0x7bc6df0
 
 type NetworkStunFunc = unsafe extern "system" fn(*const usize, *const usize) -> usize;
 


### PR DESCRIPTION
After the v2.0.4 update, mastery traits showed empty in character config and online stun stopped attributing. Same BSS shift as last time (+0x1280).

Updated:
- SAVE_ROOT / WEAPON_TABLE / CHARA_POWER
- net entity map buckets / sentinel / mask

NETWORK_STUN_SIG and actor+0xB90 still fine.